### PR TITLE
Arrays should encode length as amount of bytes when lengthType is bytes

### DIFF
--- a/src/Array.coffee
+++ b/src/Array.coffee
@@ -63,7 +63,12 @@ class ArrayT
         parent: parent
 
       ctx.pointerOffset = stream.pos + @size(array, ctx)
-      @length.encode(stream, array.length)
+
+      arrayLength = array.length
+      if @lengthType == 'bytes'
+        arrayLength *= @type.size(arrayLength, ctx)
+
+      @length.encode(stream, arrayLength)
 
     for item in array
       @type.encode(stream, item, ctx)

--- a/test/Array.coffee
+++ b/test/Array.coffee
@@ -97,3 +97,13 @@ describe 'Array', ->
       array = new ArrayT new Pointer(uint8, uint8), uint8
       array.encode(stream, [1, 2, 3, 4])
       stream.end()
+
+    it 'should encode length as amount of bytes', (done) ->
+      stream = new EncodeStream
+      stream.pipe concat (buf) ->
+        buf.should.deep.equal new Buffer [6, 0, 1, 0, 2, 0, 3]
+        done()
+
+      array = new ArrayT uint16, uint8, 'bytes'
+      array.encode(stream, [1, 2, 3])
+      stream.end()


### PR DESCRIPTION
Example:

```js
const arr = new ArrayT(uint16, uint8, 'bytes')
arr.encode(stream, [1, 2, 3]) // should be Buffer<0x6 0x0 0x1 0x0 0x2 0x0 0x3>
```