### PR TITLE
Replace new Function calls

### DIFF
--- a/src/Pointer.coffee
+++ b/src/Pointer.coffee
@@ -7,8 +7,11 @@ class Pointer
     @options.allowNull ?= true
     @options.nullValue ?= 0
     @options.lazy ?= false
-    if @options.relativeTo
-      @relativeToGetter = new Function('ctx', "return ctx.#{@options.relativeTo}")
+
+  relativeToGetter: (ctx) ->
+    @options.relativeTo.split('.').reduce((obj, prop) ->
+      obj[prop]
+    , ctx)
 
   decode: (stream, ctx) ->
     offset = @offsetType.decode(stream, ctx)

--- a/src/VersionedStruct.coffee
+++ b/src/VersionedStruct.coffee
@@ -6,7 +6,7 @@ class VersionedStruct extends Struct
   versionGetter: (parent) ->
     if typeof @type is 'string'
       @type.split('.').reduce((obj, prop) ->
-        obj[prop]
+        if typeof obj != 'undefined' then obj[prop] else undefined
       , parent)
 
   versionSetter: (parent, version) ->

--- a/src/VersionedStruct.coffee
+++ b/src/VersionedStruct.coffee
@@ -2,9 +2,18 @@ Struct = require './Struct'
 
 class VersionedStruct extends Struct
   constructor: (@type, @versions = {}) ->
+
+  versionGetter: (parent) ->
     if typeof @type is 'string'
-      @versionGetter = new Function('parent', "return parent.#{@type}")
-      @versionSetter = new Function('parent', 'version', "return parent.#{@type} = version")
+      @type.split('.').reduce((obj, prop) ->
+        obj[prop]
+      , parent)
+
+  versionSetter: (parent, version) ->
+    if typeof @type is 'string'
+      @type.split('.').reduce((obj, prop) ->
+        obj[prop] = version
+      , parent)
 
   decode: (stream, parent, length = 0) ->
     res = @_setup stream, parent, length


### PR DESCRIPTION
A slightly improved change over the pull request `firien:remove-eval`, tested against [fontkit ](https://github.com/foliojs/fontkit).

`new Function` is not allowed on sites with a Content Security Policy (CSP) and sane defaults.