### PR TITLE
Fix getting VersionedStructure version from nested parent key

### DIFF
--- a/src/VersionedStruct.js
+++ b/src/VersionedStruct.js
@@ -1,17 +1,24 @@
 const Struct = require('./Struct');
 
+const getPath = (object, pathArray) => {
+  return pathArray.reduce((prevObj, key) => prevObj && prevObj[key], object) 
+}
+
 class VersionedStruct extends Struct {
   constructor(type, versions = {}) {
     super();
     this.type = type;
     this.versions = versions;
+    if (typeof type === 'string') {
+      this.versionPath = type.split('.')
+    }
   }
 
   decode(stream, parent, length = 0) {
     const res = this._setup(stream, parent, length);
 
     if (typeof this.type === 'string') {
-      res.version = parent[this.type];
+      res.version = getPath(parent, this.versionPath);
     } else {
       res.version = this.type.decode(stream);
     }

--- a/test/VersionedStruct.js
+++ b/test/VersionedStruct.js
@@ -116,6 +116,36 @@ describe('VersionedStruct', function() {
       });
     });
 
+    it('should support parent version nested key', function() {
+      const struct = new VersionedStruct('obj.version', {
+        0: {
+          name: new StringT(uint8, 'ascii'),
+          age: uint8
+        },
+        1: {
+          name: new StringT(uint8, 'utf8'),
+          age: uint8,
+          gender: uint8
+        }
+      }
+      );
+
+      let stream = new DecodeStream(Buffer.from('\x05devon\x15'));
+      struct.decode(stream, {obj: {version: 0}}).should.deep.equal({
+        version: 0,
+        name: 'devon',
+        age: 21
+      });
+
+      stream = new DecodeStream(Buffer.from('\x0adevon 👍\x15\x00', 'utf8'));
+      return struct.decode(stream, {obj: {version: 1}}).should.deep.equal({
+        version: 1,
+        name: 'devon 👍',
+        age: 21,
+        gender: 0
+      });
+    });
+
     it('should support sub versioned structs', function() {
       const struct = new VersionedStruct(uint8, {
         0: {


### PR DESCRIPTION
Fixes when using a nested version path to VersionedStructure. 

Adds a test

This feature is used by fontkit