### PR TITLE
export PropertyDescriptor and resolveLength

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-let key, val;
 exports.EncodeStream    = require('./src/EncodeStream');
 exports.DecodeStream    = require('./src/DecodeStream');
 exports.Array           = require('./src/Array');
@@ -13,14 +12,8 @@ exports.String          = require('./src/String');
 exports.Struct          = require('./src/Struct');
 exports.VersionedStruct = require('./src/VersionedStruct');
 
-const object = require('./src/Number');
-for (key in object) {
-  val = object[key];
-  exports[key] = val;
-}
+const utils             = require('./src/utils');
+const NumberT           = require('./src/Number');
+const Pointer           = require('./src/Pointer');
 
-const object1 = require('./src/Pointer');
-for (key in object1) {
-  val = object1[key];
-  exports[key] = val;
-}
+Object.assign(exports, utils, NumberT, Pointer);


### PR DESCRIPTION
PropertyDescriptor and resolveLength are used by fontkit

Currently fontkit [imports directly from the src folder](https://github.com/foliojs/fontkit/blob/f3f55a07d0bc54974b806601832c8cb0eb973d74/src/cff/CFFTop.js#L2) which is far from ideal

This PR also removes the custom, local assign method (an artifact from CoffeeScript conversion) in favor of native Object assign