### PR TITLE
Drop node dependencies

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 coverage.html
 coverage/
 node_modules/
+.parcel-cache
+dist

--- a/README.md
+++ b/README.md
@@ -162,8 +162,9 @@ var struct = new r.Struct({
 A `String` maps a JavaScript string to and from binary encodings.  The length can be a constant, taken
 from a previous field in the parent structure, or encoded using a number type immediately before the string.
 
-Supported encodings include `'ascii'`, `'utf8'`, `'ucs2'`, `'utf16le'`, `'utf16be'`, and if you also install
-[iconv-lite](https://github.com/ashtuchkin/iconv-lite), many other legacy codecs.
+Fully supported encodings include `'ascii'`, `'utf8'`, `'ucs2'`, `'utf16le'`, `'utf16be'`. Decoding is also possible
+with any encoding supported by [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API/Encodings),
+however encoding these is not supported.
 
 ```javascript
 // fixed length, ascii encoding by default

--- a/README.md
+++ b/README.md
@@ -17,38 +17,30 @@ This is just a small example of what Restructure can do. Check out the API docum
 below for more information.
 
 ```javascript
-var r = require('restructure');
+import * as r from 'restructure';
 
-var Person = new r.Struct({
+let Person = new r.Struct({
   name: new r.String(r.uint8, 'utf8'),
   age: r.uint8
 });
 
 // decode a person from a buffer
-var stream = new r.DecodeStream(buffer);
-Person.decode(stream); // returns an object with the fields defined above
+let value = Person.fromBuffer(new Uint8Array([/* ... */])); // returns an object with the fields defined above
 
 // encode a person from an object
-// pipe the stream to a destination, such as a file
-var stream = new r.EncodeStream();
-stream.pipe(fs.createWriteStream('out.bin'));
-
-Person.encode(stream, {
+let buffer = Person.toBuffer({
   name: 'Devon',
   age: 21
 });
-
-stream.end();
 ```
-
 
 ## API
 
 All of the following types support three standard methods:
 
-* `decode(stream)` - decodes an instance of the type from the given DecodeStream
+* `fromBuffer(buffer)` - decodes an instance of the type from the given Uint8Array
 * `size(value)` - returns the amount of space the value would take if encoded
-* `encode(stream, value)` - encodes the given value into the given EncodeStream
+* `toBuffer(value)` - encodes the given value into a Uint8Array
 
 Restructure supports a wide variety of types, but if you need to write your own for
 some custom use that cannot be represented by them, you can do so by just implementing
@@ -143,7 +135,7 @@ bitfield.encode(stream, result);
 
 ### Buffer
 
-Extracts a slice of the buffer to a Node `Buffer`.  The length can be a constant, or taken from
+Extracts a slice of the buffer to a `Uint8Array`.  The length can be a constant, or taken from
 a previous field in the parent structure.
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -1,19 +1,17 @@
-exports.EncodeStream    = require('./src/EncodeStream');
-exports.DecodeStream    = require('./src/DecodeStream');
-exports.Array           = require('./src/Array');
-exports.LazyArray       = require('./src/LazyArray');
-exports.Bitfield        = require('./src/Bitfield');
-exports.Boolean         = require('./src/Boolean');
-exports.Buffer          = require('./src/Buffer');
-exports.Enum            = require('./src/Enum');
-exports.Optional        = require('./src/Optional');
-exports.Reserved        = require('./src/Reserved');
-exports.String          = require('./src/String');
-exports.Struct          = require('./src/Struct');
-exports.VersionedStruct = require('./src/VersionedStruct');
+export {EncodeStream} from './src/EncodeStream.js';
+export {DecodeStream} from './src/DecodeStream.js';
+export {Array} from './src/Array.js';
+export {LazyArray} from './src/LazyArray.js';
+export {Bitfield} from './src/Bitfield.js';
+export {Boolean} from './src/Boolean.js';
+export {Buffer} from './src/Buffer.js';
+export {Enum} from './src/Enum.js';
+export {Optional} from './src/Optional.js';
+export {Reserved} from './src/Reserved.js';
+export {String} from './src/String.js';
+export {Struct} from './src/Struct.js';
+export {VersionedStruct} from './src/VersionedStruct.js';
 
-const utils             = require('./src/utils');
-const NumberT           = require('./src/Number');
-const Pointer           = require('./src/Pointer');
-
-Object.assign(exports, utils, NumberT, Pointer);
+export * from './src/utils.js';
+export * from './src/Number.js';
+export * from './src/Pointer.js';

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "chai": "~4.2.0",
     "concat-stream": "~2.0.0",
     "coveralls": "^3.0.11",
-    "iconv-lite": "^0.5.1",
     "mocha": "~7.1.1",
     "nyc": "^15.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -3,17 +3,24 @@
   "version": "2.0.1",
   "description": "Declaratively encode and decode binary data",
   "type": "module",
-  "main": "index.js",
+  "main": "./dist/main.cjs",
+  "module": "./index.js",
+  "source": "./index.js",
   "exports": {
-    "import": "./index.js"
+    "import": "./index.js",
+    "require": "./dist/main.cjs"
+  },
+  "targets": {
+    "module": false
   },
   "devDependencies": {
-    "mocha": "^10.0.0"
+    "mocha": "^10.0.0",
+    "parcel": "^2.6.1"
   },
   "scripts": {
     "test": "mocha",
-    "cover": "nyc --reporter=html --reporter=text mocha",
-    "coveralls": "nyc report --reporter=text-lcov | coveralls"
+    "build": "parcel build",
+    "prepublishOnly": "parcel build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,16 +2,16 @@
   "name": "restructure",
   "version": "2.0.1",
   "description": "Declaratively encode and decode binary data",
+  "type": "module",
   "main": "index.js",
+  "exports": {
+    "import": "./index.js"
+  },
   "devDependencies": {
-    "chai": "~4.2.0",
-    "concat-stream": "~2.0.0",
-    "coveralls": "^3.0.11",
-    "mocha": "~7.1.1",
-    "nyc": "^15.0.1"
+    "mocha": "^10.0.0"
   },
   "scripts": {
-    "test": "mocha --reporter spec",
+    "test": "mocha",
     "cover": "nyc --reporter=html --reporter=text mocha",
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },

--- a/src/Array.js
+++ b/src/Array.js
@@ -69,7 +69,7 @@ class ArrayT extends Base {
       size += this.type.size(item, ctx);
     }
 
-    if (ctx && includePointers) {
+    if (ctx && includePointers && this.length instanceof NumberT) {
       size += ctx.pointerSize;
     }
     
@@ -94,8 +94,10 @@ class ArrayT extends Base {
     }
 
     if (this.length instanceof NumberT) {
-      for (let ptr of ctx.pointers) {
-        ptr.type.encode(stream, ptr.val);
+      let i = 0;
+      while (i < ctx.pointers.length) {
+        const ptr = ctx.pointers[i++];
+        ptr.type.encode(stream, ptr.val, ptr.parent);
       }
     }
   }

--- a/src/Array.js
+++ b/src/Array.js
@@ -1,8 +1,10 @@
-const {Number:NumberT} = require('./Number');
-const utils = require('./utils');
+import {Base} from './Base.js';
+import {Number as NumberT} from './Number.js';
+import * as utils from './utils.js';
 
-class ArrayT {
+class ArrayT extends Base {
   constructor(type, length, lengthType = 'count') {
+    super();
     this.type = type;
     this.length = length;
     this.lengthType = lengthType;
@@ -52,7 +54,7 @@ class ArrayT {
     return res;
   }
 
-  size(array, ctx) {
+  size(array, ctx, includePointers = true) {
     if (!array) {
       return this.type.size(null, ctx) * utils.resolveLength(this.length, null, ctx);
     }
@@ -60,13 +62,17 @@ class ArrayT {
     let size = 0;
     if (this.length instanceof NumberT) {
       size += this.length.size();
-      ctx = {parent: ctx};
+      ctx = {parent: ctx, pointerSize: 0};
     }
 
     for (let item of array) {
       size += this.type.size(item, ctx);
     }
 
+    if (ctx && includePointers) {
+      size += ctx.pointerSize;
+    }
+    
     return size;
   }
 
@@ -79,7 +85,7 @@ class ArrayT {
         parent
       };
 
-      ctx.pointerOffset = stream.pos + this.size(array, ctx);
+      ctx.pointerOffset = stream.pos + this.size(array, ctx, false);
       this.length.encode(stream, array.length);
     }
 
@@ -88,14 +94,11 @@ class ArrayT {
     }
 
     if (this.length instanceof NumberT) {
-      let i = 0;
-      while (i < ctx.pointers.length) {
-        const ptr = ctx.pointers[i++];
+      for (let ptr of ctx.pointers) {
         ptr.type.encode(stream, ptr.val);
       }
     }
-
   }
 }
 
-module.exports = ArrayT;
+export {ArrayT as Array};

--- a/src/Base.js
+++ b/src/Base.js
@@ -1,0 +1,17 @@
+import {DecodeStream} from './DecodeStream.js';
+import {EncodeStream} from './EncodeStream.js';
+
+export class Base {
+  fromBuffer(buffer) {
+    let stream = new DecodeStream(buffer);
+    return this.decode(stream);
+  }
+
+  toBuffer(value) {
+    let size = this.size(value);
+    let buffer = new Uint8Array(size);
+    let stream = new EncodeStream(buffer);
+    this.encode(stream, value);
+    return buffer;
+  }
+}

--- a/src/Bitfield.js
+++ b/src/Bitfield.js
@@ -1,8 +1,12 @@
-class Bitfield {
+import {Base} from './Base.js';
+
+export class Bitfield extends Base {
   constructor(type, flags = []) {
+    super();
     this.type = type;
     this.flags = flags;
   }
+
   decode(stream) {
     const val = this.type.decode(stream);
 
@@ -33,5 +37,3 @@ class Bitfield {
     return this.type.encode(stream, val);
   }
 }
-
-module.exports = Bitfield;

--- a/src/Boolean.js
+++ b/src/Boolean.js
@@ -1,5 +1,8 @@
-class BooleanT {
+import {Base} from './Base.js';
+
+export class BooleanT extends Base {
   constructor(type) {
+    super();
     this.type = type;
   }
 
@@ -16,4 +19,4 @@ class BooleanT {
   }
 }
 
-module.exports = BooleanT;
+export {BooleanT as Boolean};

--- a/src/Buffer.js
+++ b/src/Buffer.js
@@ -1,8 +1,10 @@
-const utils = require('./utils');
-const {Number:NumberT} = require('./Number');
+import {Base} from './Base.js';
+import {Number as NumberT} from './Number.js';
+import * as utils from './utils.js';
 
-class BufferT {
+export class BufferT extends Base {
   constructor(length) {
+    super();
     this.length = length;
   }
   decode(stream, parent) {
@@ -15,7 +17,12 @@ class BufferT {
       return utils.resolveLength(this.length, null, parent);
     }
 
-    return val.length;
+    let len = val.length;
+    if (this.length instanceof NumberT) {
+      len += this.length.size();
+    }
+
+    return len;
   }
 
   encode(stream, buf, parent) {
@@ -27,4 +34,4 @@ class BufferT {
   }
 }
 
-module.exports = BufferT;
+export {BufferT as Buffer};

--- a/src/Buffer.js
+++ b/src/Buffer.js
@@ -7,6 +7,7 @@ export class BufferT extends Base {
     super();
     this.length = length;
   }
+  
   decode(stream, parent) {
     const length = utils.resolveLength(this.length, stream, parent);
     return stream.readBuffer(length);

--- a/src/DecodeStream.js
+++ b/src/DecodeStream.js
@@ -1,39 +1,27 @@
-let iconv;
-try { iconv = require('iconv-lite'); } catch (error) {}
+// Node back-compat.
+const ENCODING_MAPPING = {
+  utf16le: 'utf-16le',
+  ucs2: 'utf-16le',
+  utf16be: 'utf-16be'
+}
 
 class DecodeStream {
   constructor(buffer) {
     this.buffer = buffer;
+    this.view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
     this.pos = 0;
     this.length = this.buffer.length;
   }
 
   readString(length, encoding = 'ascii') {
-    switch (encoding) {
-      case 'utf16le': case 'ucs2': case 'utf8': case 'ascii':
-        return this.buffer.toString(encoding, this.pos, (this.pos += length));
+    encoding = ENCODING_MAPPING[encoding] || encoding;
 
-      case 'utf16be':
-        var buf = Buffer.from(this.readBuffer(length));
-
-        // swap the bytes
-        for (let i = 0, end = buf.length - 1; i < end; i += 2) {
-          const byte = buf[i];
-          buf[i] = buf[i + 1];
-          buf[i + 1] = byte;
-        }
-
-        return buf.toString('utf16le');
-
-      default:
-        buf = this.readBuffer(length);
-        if (iconv) {
-          try {
-            return iconv.decode(buf, encoding);
-          } catch (error1) {}
-        }
-
-        return buf;
+    let buf = this.readBuffer(length);
+    try {
+      let decoder = new TextDecoder(encoding);
+      return decoder.decode(buf);
+    } catch (err) {
+      return buf;
     }
   }
 
@@ -71,14 +59,28 @@ DecodeStream.TYPES = {
   Double: 8
 };
 
-for (let key in Buffer.prototype) {
-  if (key.slice(0, 4) === 'read') {
-    const bytes = DecodeStream.TYPES[key.replace(/read|[BL]E/g, '')];
-    DecodeStream.prototype[key] = function() {
-      const ret = this.buffer[key](this.pos);
+for (let key of Object.getOwnPropertyNames(DataView.prototype)) {
+  if (key.slice(0, 3) === 'get') {
+    let type = key.slice(3).replace('Ui', 'UI');
+    if (type === 'Float32') {
+      type = 'Float';
+    } else if (type === 'Float64') {
+      type = 'Double';
+    }
+    let bytes = DecodeStream.TYPES[type];
+    DecodeStream.prototype['read' + type + (bytes === 1 ? '' : 'BE')] = function () {
+      const ret = this.view[key](this.pos, false);
       this.pos += bytes;
       return ret;
     };
+
+    if (bytes !== 1) {
+      DecodeStream.prototype['read' + type + 'LE'] = function () {
+        const ret = this.view[key](this.pos, true);
+        this.pos += bytes;
+        return ret;
+      };
+    }
   }
 }
 

--- a/src/DecodeStream.js
+++ b/src/DecodeStream.js
@@ -5,7 +5,7 @@ const ENCODING_MAPPING = {
   utf16be: 'utf-16be'
 }
 
-class DecodeStream {
+export class DecodeStream {
   constructor(buffer) {
     this.buffer = buffer;
     this.view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
@@ -83,5 +83,3 @@ for (let key of Object.getOwnPropertyNames(DataView.prototype)) {
     }
   }
 }
-
-module.exports = DecodeStream;

--- a/src/EncodeStream.js
+++ b/src/EncodeStream.js
@@ -6,7 +6,7 @@ const isBigEndian = new Uint8Array(new Uint16Array([0x1234]).buffer)[0] == 0x12;
 export class EncodeStream {
   constructor(buffer) {
     this.buffer = buffer;
-    this.view = new DataView(this.buffer.buffer);
+    this.view = new DataView(this.buffer.buffer, this.buffer.byteOffset, this.buffer.byteLength);
     this.pos = 0;
   }
 

--- a/src/Enum.js
+++ b/src/Enum.js
@@ -1,8 +1,12 @@
-class Enum {
+import {Base} from './Base.js';
+
+export class Enum extends Base {
   constructor(type, options = []) {
+    super();
     this.type = type;
     this.options = options;
   }
+  
   decode(stream) {
     const index = this.type.decode(stream);
     return this.options[index] || index;
@@ -21,5 +25,3 @@ class Enum {
     return this.type.encode(stream, index);
   }
 }
-
-module.exports = Enum;

--- a/src/LazyArray.js
+++ b/src/LazyArray.js
@@ -1,7 +1,6 @@
 const ArrayT = require('./Array');
 const {Number:NumberT} = require('./Number');
 const utils = require('./utils');
-const {inspect} = require('util');
 
 class LazyArrayT extends ArrayT {
   decode(stream, parent) {
@@ -71,10 +70,6 @@ class LazyArray {
       result.push(this.get(i));
     }
     return result;
-  }
-
-  inspect() {
-    return inspect(this.toArray());
   }
 }
 

--- a/src/LazyArray.js
+++ b/src/LazyArray.js
@@ -1,8 +1,8 @@
-const ArrayT = require('./Array');
-const {Number:NumberT} = require('./Number');
-const utils = require('./utils');
+import {Array as ArrayT} from './Array.js';
+import {Number as NumberT} from './Number.js';
+import * as utils from './utils.js';
 
-class LazyArrayT extends ArrayT {
+export class LazyArray extends ArrayT {
   decode(stream, parent) {
     const { pos } = stream;
     const length = utils.resolveLength(this.length, stream, parent);
@@ -16,14 +16,14 @@ class LazyArrayT extends ArrayT {
       };
     }
 
-    const res = new LazyArray(this.type, length, stream, parent);
+    const res = new LazyArrayValue(this.type, length, stream, parent);
 
     stream.pos += length * this.type.size(null, parent);
     return res;
   }
 
   size(val, ctx) {
-    if (val instanceof LazyArray) {
+    if (val instanceof LazyArrayValue) {
       val = val.toArray();
     }
 
@@ -31,7 +31,7 @@ class LazyArrayT extends ArrayT {
   }
 
   encode(stream, val, ctx) {
-    if (val instanceof LazyArray) {
+    if (val instanceof LazyArrayValue) {
       val = val.toArray();
     }
 
@@ -39,7 +39,7 @@ class LazyArrayT extends ArrayT {
   }
 }
 
-class LazyArray {
+class LazyArrayValue {
   constructor(type, length, stream, ctx) {
     this.type = type;
     this.length = length;
@@ -72,5 +72,3 @@ class LazyArray {
     return result;
   }
 }
-
-module.exports = LazyArrayT;

--- a/src/Number.js
+++ b/src/Number.js
@@ -61,5 +61,5 @@ class Fixed extends NumberT {
 exports.Fixed = Fixed;
 exports.fixed16be = (exports.fixed16 = new Fixed(16, 'BE'));
 exports.fixed16le = new Fixed(16, 'LE');
-exports.fixed32be = (exports.fixed32 =new Fixed(32, 'BE'));
+exports.fixed32be = (exports.fixed32 = new Fixed(32, 'BE'));
 exports.fixed32le = new Fixed(32, 'LE');

--- a/src/Number.js
+++ b/src/Number.js
@@ -1,7 +1,9 @@
-const DecodeStream = require('./DecodeStream');
+import {DecodeStream} from './DecodeStream.js';
+import {Base} from './Base.js';
 
-class NumberT {
+class NumberT extends Base {
   constructor(type, endian = 'BE') {
+    super();
     this.type = type;
     this.endian = endian;
     this.fn = this.type;
@@ -23,27 +25,36 @@ class NumberT {
   }
 }
 
-exports.Number = NumberT;
-exports.uint8 = new NumberT('UInt8');
-exports.uint16be = (exports.uint16 = new NumberT('UInt16', 'BE'));
-exports.uint16le = new NumberT('UInt16', 'LE');
-exports.uint24be = (exports.uint24 = new NumberT('UInt24', 'BE'));
-exports.uint24le = new NumberT('UInt24', 'LE');
-exports.uint32be = (exports.uint32 = new NumberT('UInt32', 'BE'));
-exports.uint32le = new NumberT('UInt32', 'LE');
-exports.int8 = new NumberT('Int8');
-exports.int16be = (exports.int16 = new NumberT('Int16', 'BE'));
-exports.int16le = new NumberT('Int16', 'LE');
-exports.int24be = (exports.int24 = new NumberT('Int24', 'BE'));
-exports.int24le = new NumberT('Int24', 'LE');
-exports.int32be = (exports.int32 = new NumberT('Int32', 'BE'));
-exports.int32le = new NumberT('Int32', 'LE');
-exports.floatbe = (exports.float = new NumberT('Float', 'BE'));
-exports.floatle = new NumberT('Float', 'LE');
-exports.doublebe = (exports.double = new NumberT('Double', 'BE'));
-exports.doublele = new NumberT('Double', 'LE');
+export {NumberT as Number};
 
-class Fixed extends NumberT {
+export const uint8 = new NumberT('UInt8');
+export const uint16be = new NumberT('UInt16', 'BE');
+export const uint16 = uint16be;
+export const uint16le = new NumberT('UInt16', 'LE');
+export const uint24be = new NumberT('UInt24', 'BE');
+export const uint24 = uint24be;
+export const uint24le = new NumberT('UInt24', 'LE');
+export const uint32be = new NumberT('UInt32', 'BE');
+export const uint32 = uint32be;
+export const uint32le = new NumberT('UInt32', 'LE');
+export const int8 = new NumberT('Int8');
+export const int16be = new NumberT('Int16', 'BE');
+export const int16 = int16be;
+export const int16le = new NumberT('Int16', 'LE');
+export const int24be = new NumberT('Int24', 'BE');
+export const int24 = int24be;
+export const int24le = new NumberT('Int24', 'LE');
+export const int32be = new NumberT('Int32', 'BE');
+export const int32 = int32be;
+export const int32le = new NumberT('Int32', 'LE');
+export const floatbe = new NumberT('Float', 'BE');
+export const float = floatbe;
+export const floatle = new NumberT('Float', 'LE');
+export const doublebe = new NumberT('Double', 'BE');
+export const double = doublebe;
+export const doublele = new NumberT('Double', 'LE');
+
+export class Fixed extends NumberT {
   constructor(size, endian, fracBits = size >> 1) {
     super(`Int${size}`, endian);
     this._point = 1 << fracBits;
@@ -58,8 +69,9 @@ class Fixed extends NumberT {
   }
 }
 
-exports.Fixed = Fixed;
-exports.fixed16be = (exports.fixed16 = new Fixed(16, 'BE'));
-exports.fixed16le = new Fixed(16, 'LE');
-exports.fixed32be = (exports.fixed32 = new Fixed(32, 'BE'));
-exports.fixed32le = new Fixed(32, 'LE');
+export const fixed16be = new Fixed(16, 'BE');
+export const fixed16 = fixed16be;
+export const fixed16le = new Fixed(16, 'LE');
+export const fixed32be = new Fixed(32, 'BE');
+export const fixed32 = fixed32be;
+export const fixed32le = new Fixed(32, 'LE');

--- a/src/Optional.js
+++ b/src/Optional.js
@@ -1,5 +1,8 @@
-class Optional {
+import {Base} from './Base.js';
+
+export class Optional extends Base {
   constructor(type, condition = true) {
+    super();
     this.type = type;
     this.condition = condition;
   }
@@ -39,5 +42,3 @@ class Optional {
     }
   }
 }
-
-module.exports = Optional;

--- a/src/Pointer.js
+++ b/src/Pointer.js
@@ -98,7 +98,9 @@ export class Pointer extends Base {
     }
 
     if (val && ctx) {
-      ctx.pointerSize += type.size(val, parent);
+      // Must be written as two separate lines rather than += in case `type.size` mutates ctx.pointerSize.
+      let size = type.size(val, parent);
+      ctx.pointerSize += size;
     }
 
     return this.offsetType.size();

--- a/src/Pointer.js
+++ b/src/Pointer.js
@@ -1,7 +1,9 @@
-const utils = require('./utils');
+import * as utils from './utils.js';
+import {Base} from './Base.js';
 
-class Pointer {
+export class Pointer extends Base {
   constructor(offsetType, type, options = {}) {
+    super();
     this.offsetType = offsetType;
     this.type = type;
     this.options = options;
@@ -155,12 +157,9 @@ class Pointer {
 }
 
 // A pointer whose type is determined at decode time
-class VoidPointer {
+export class VoidPointer {
   constructor(type, value) {
     this.type = type;
     this.value = value;
   }
 }
-
-exports.Pointer = Pointer;
-exports.VoidPointer = VoidPointer;

--- a/src/Reserved.js
+++ b/src/Reserved.js
@@ -1,7 +1,9 @@
-const utils = require('./utils');
+import {Base} from './Base.js';
+import * as utils from './utils.js';
 
-class Reserved {
+export class Reserved extends Base {
   constructor(type, count = 1) {
+    super();
     this.type = type;
     this.count = count;
   }
@@ -19,5 +21,3 @@ class Reserved {
     return stream.fill(0, this.size(val, parent));
   }
 }
-
-module.exports = Reserved;

--- a/src/String.js
+++ b/src/String.js
@@ -1,8 +1,10 @@
-const {Number:NumberT} = require('./Number');
-const utils = require('./utils');
+import {Base} from './Base.js';
+import {Number as NumberT} from './Number.js';
+import * as utils from './utils.js';
 
-class StringT {
+class StringT extends Base {
   constructor(length, encoding = 'ascii') {
+    super();
     this.length = length;
     this.encoding = encoding;
   }
@@ -123,4 +125,4 @@ function byteLength(string, encoding) {
   }
 }
 
-module.exports = StringT;
+export {StringT as String};

--- a/src/Struct.js
+++ b/src/Struct.js
@@ -1,7 +1,9 @@
-const utils = require('./utils');
+import {Base} from './Base.js';
+import * as utils from './utils.js';
 
-class Struct {
+export class Struct extends Base {
   constructor(fields = {}) {
+    super();
     this.fields = fields;
   }
 
@@ -52,9 +54,7 @@ class Struct {
 
   }
 
-  size(val, parent, includePointers) {
-    if (val == null) { val = {}; }
-    if (includePointers == null) { includePointers = true; }
+  size(val = {}, parent, includePointers = true) {
     const ctx = {
       parent,
       val,
@@ -104,8 +104,5 @@ class Struct {
       const ptr = ctx.pointers[i++];
       ptr.type.encode(stream, ptr.val, ptr.parent);
     }
-
   }
 }
-
-module.exports = Struct;

--- a/src/Struct.js
+++ b/src/Struct.js
@@ -54,12 +54,17 @@ export class Struct extends Base {
 
   }
 
-  size(val = {}, parent, includePointers = true) {
+  size(val, parent, includePointers = true) {
+    if (val == null) { val = {}; }
     const ctx = {
       parent,
       val,
       pointerSize: 0
     };
+
+    if (this.preEncode != null) {
+      this.preEncode.call(val);
+    }
 
     let size = 0;
     for (let key in this.fields) {

--- a/src/VersionedStruct.js
+++ b/src/VersionedStruct.js
@@ -1,10 +1,10 @@
-const Struct = require('./Struct');
+import {Struct} from './Struct.js';
 
 const getPath = (object, pathArray) => {
   return pathArray.reduce((prevObj, key) => prevObj && prevObj[key], object);
 };
 
-class VersionedStruct extends Struct {
+export class VersionedStruct extends Struct {
   constructor(type, versions = {}) {
     super();
     this.type = type;
@@ -48,6 +48,10 @@ class VersionedStruct extends Struct {
     let key, type;
     if (!val) {
       throw new Error('Not a fixed size');
+    }
+
+    if (this.preEncode != null) {
+      this.preEncode.call(val);
     }
 
     const ctx = {
@@ -131,8 +135,5 @@ class VersionedStruct extends Struct {
       const ptr = ctx.pointers[i++];
       ptr.type.encode(stream, ptr.val, ptr.parent);
     }
-
   }
 }
-
-module.exports = VersionedStruct;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
-const {Number:NumberT} = require('./Number');
+import {Number as NumberT} from './Number.js';
 
-exports.resolveLength = function(length, stream, parent) {
+export function resolveLength(length, stream, parent) {
   let res;
   if (typeof length === 'number') {
     res = length;
@@ -22,7 +22,7 @@ exports.resolveLength = function(length, stream, parent) {
   return res;
 };
 
-class PropertyDescriptor {
+export class PropertyDescriptor {
   constructor(opts = {}) {
     this.enumerable = true;
     this.configurable = true;
@@ -33,5 +33,3 @@ class PropertyDescriptor {
     }
   }
 }
-
-exports.PropertyDescriptor = PropertyDescriptor;

--- a/test/Array.js
+++ b/test/Array.js
@@ -1,125 +1,103 @@
-const {Array:ArrayT, Pointer, uint8, uint16, DecodeStream, EncodeStream} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+import assert from 'assert';
+import {Array as ArrayT, Pointer, uint8, uint16, DecodeStream, EncodeStream} from 'restructure';
 
 describe('Array', function() {
   describe('decode', function() {
     it('should decode fixed length', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3, 4, 5]));
+      const buffer = new Uint8Array([1, 2, 3, 4, 5]);
       const array = new ArrayT(uint8, 4);
-      return array.decode(stream).should.deep.equal([1, 2, 3, 4]);
-  });
+      assert.deepEqual(array.fromBuffer(buffer), [1, 2, 3, 4]);
+    });
 
     it('should decode fixed amount of bytes', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3, 4, 5]));
+      const buffer = new Uint8Array([1, 2, 3, 4, 5]);
       const array = new ArrayT(uint16, 4, 'bytes');
-      return array.decode(stream).should.deep.equal([258, 772]);
-  });
+      assert.deepEqual(array.fromBuffer(buffer), [258, 772]);
+    });
 
     it('should decode length from parent key', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3, 4, 5]));
+      const stream = new DecodeStream(new Uint8Array([1, 2, 3, 4, 5]));
       const array = new ArrayT(uint8, 'len');
-      return array.decode(stream, {len: 4}).should.deep.equal([1, 2, 3, 4]);
-  });
+      assert.deepEqual(array.decode(stream, {len: 4}), [1, 2, 3, 4]);
+    });
 
     it('should decode amount of bytes from parent key', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3, 4, 5]));
+      const stream = new DecodeStream(new Uint8Array([1, 2, 3, 4, 5]));
       const array = new ArrayT(uint16, 'len', 'bytes');
-      return array.decode(stream, {len: 4}).should.deep.equal([258, 772]);
-  });
+      assert.deepEqual(array.decode(stream, {len: 4}), [258, 772]);
+    });
 
     it('should decode length as number before array', function() {
-      const stream = new DecodeStream(Buffer.from([4, 1, 2, 3, 4, 5]));
+      const buffer = new Uint8Array([4, 1, 2, 3, 4, 5]);
       const array = new ArrayT(uint8, uint8);
-      return array.decode(stream).should.deep.equal([1, 2, 3, 4]);
-  });
+      assert.deepEqual(array.fromBuffer(buffer), [1, 2, 3, 4]);
+    });
 
     it('should decode amount of bytes as number before array', function() {
-      const stream = new DecodeStream(Buffer.from([4, 1, 2, 3, 4, 5]));
+      const buffer = new Uint8Array([4, 1, 2, 3, 4, 5]);
       const array = new ArrayT(uint16, uint8, 'bytes');
-      return array.decode(stream).should.deep.equal([258, 772]);
-  });
+      assert.deepEqual(array.fromBuffer(buffer), [258, 772]);
+    });
 
     it('should decode length from function', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3, 4, 5]));
+      const buffer = new Uint8Array([1, 2, 3, 4, 5]);
       const array = new ArrayT(uint8, function() { return 4; });
-      return array.decode(stream).should.deep.equal([1, 2, 3, 4]);
-  });
+      assert.deepEqual(array.fromBuffer(buffer), [1, 2, 3, 4]);
+    });
 
     it('should decode amount of bytes from function', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3, 4, 5]));
+      const buffer = new Uint8Array([1, 2, 3, 4, 5]);
       const array = new ArrayT(uint16, (function() { return 4; }), 'bytes');
-      return array.decode(stream).should.deep.equal([258, 772]);
-  });
+      assert.deepEqual(array.fromBuffer(buffer), [258, 772]);
+    });
 
     it('should decode to the end of the parent if no length is given', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3, 4, 5]));
+      const stream = new DecodeStream(new Uint8Array([1, 2, 3, 4, 5]));
       const array = new ArrayT(uint8);
-      return array.decode(stream, {_length: 4, _startOffset: 0}).should.deep.equal([1, 2, 3, 4]);
-  });
+      assert.deepEqual(array.decode(stream, {_length: 4, _startOffset: 0}), [1, 2, 3, 4]);
+    });
 
-    return it('should decode to the end of the stream if no parent and length is given', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3, 4]));
+    it('should decode to the end of the stream if no parent and length is given', function() {
+      const buffer = new Uint8Array([1, 2, 3, 4]);
       const array = new ArrayT(uint8);
-      return array.decode(stream).should.deep.equal([1, 2, 3, 4]);
+      assert.deepEqual(array.fromBuffer(buffer), [1, 2, 3, 4]);
+    });
   });
-});
 
   describe('size', function() {
     it('should use array length', function() {
       const array = new ArrayT(uint8, 10);
-      return array.size([1, 2, 3, 4]).should.equal(4);
+      assert.equal(array.size([1, 2, 3, 4]), 4);
     });
 
     it('should add size of length field before string', function() {
       const array = new ArrayT(uint8, uint8);
-      return array.size([1, 2, 3, 4]).should.equal(5);
+      assert.equal(array.size([1, 2, 3, 4]), 5);
     });
 
-    return it('should use defined length if no value given', function() {
+    it('should use defined length if no value given', function() {
       const array = new ArrayT(uint8, 10);
-      return array.size().should.equal(10);
+      assert.equal(array.size(), 10);
     });
   });
 
-  return describe('encode', function() {
-    it('should encode using array length', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([1, 2, 3, 4]));
-        return done();
-      })
-      );
-
+  describe('encode', function() {
+    it('should encode using array length', function() {
       const array = new ArrayT(uint8, 10);
-      array.encode(stream, [1, 2, 3, 4]);
-      return stream.end();
+      const buffer = array.toBuffer([1, 2, 3, 4]);
+      assert.deepEqual(buffer, new Uint8Array([1, 2, 3, 4]));
     });
 
-    it('should encode length as number before array', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([4, 1, 2, 3, 4]));
-        return done();
-      })
-      );
-
+    it('should encode length as number before array', function() {
       const array = new ArrayT(uint8, uint8);
-      array.encode(stream, [1, 2, 3, 4]);
-      return stream.end();
+      const buffer = array.toBuffer([1, 2, 3, 4]);
+      assert.deepEqual(buffer, new Uint8Array([4, 1, 2, 3, 4]));
     });
 
-    return it('should add pointers after array if length is encoded at start', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([4, 5, 6, 7, 8, 1, 2, 3, 4]));
-        return done();
-      })
-      );
-
+    it('should add pointers after array if length is encoded at start', function() {
       const array = new ArrayT(new Pointer(uint8, uint8), uint8);
-      array.encode(stream, [1, 2, 3, 4]);
-      return stream.end();
+      const buffer = array.toBuffer([1, 2, 3, 4]);
+      assert.deepEqual(buffer, new Uint8Array([4, 5, 6, 7, 8, 1, 2, 3, 4]));
     });
   });
 });

--- a/test/Bitfield.js
+++ b/test/Bitfield.js
@@ -1,6 +1,5 @@
-const {Bitfield, uint8, DecodeStream, EncodeStream} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+import assert from 'assert';
+import {Bitfield, uint8, DecodeStream, EncodeStream} from 'restructure';
 
 describe('Bitfield', function() {
   const bitfield = new Bitfield(uint8, ['Jack', 'Kack', 'Lack', 'Mack', 'Nack', 'Oack', 'Pack', 'Quack']);
@@ -13,23 +12,18 @@ describe('Bitfield', function() {
   const PACK  = 1 << 6;
   const QUACK = 1 << 7;
 
-  it('should have the right size', () => bitfield.size().should.equal(1));
+  it('should have the right size', () => assert.equal(bitfield.size(), 1));
 
   it('should decode', function() {
-    const stream = new DecodeStream(Buffer.from([JACK | MACK | PACK | NACK | QUACK]));
-    return bitfield.decode(stream).should.deep.equal({
-      Jack: true, Kack: false, Lack: false, Mack: true, Nack: true, Oack: false, Pack: true, Quack: true});
+    const buffer = new Uint8Array([JACK | MACK | PACK | NACK | QUACK]);
+    assert.deepEqual(
+      bitfield.fromBuffer(buffer),
+      {Jack: true, Kack: false, Lack: false, Mack: true, Nack: true, Oack: false, Pack: true, Quack: true}
+    );
   });
 
-  return it('should encode', function(done) {
-    const stream = new EncodeStream;
-    stream.pipe(concat(function(buf) {
-      buf.should.deep.equal(Buffer.from([JACK | MACK | PACK | NACK | QUACK]));
-      return done();
-    })
-    );
-
-    bitfield.encode(stream, {Jack: true, Kack: false, Lack: false, Mack: true, Nack: true, Oack: false, Pack: true, Quack: true});
-    return stream.end();
+  it('should encode', function() {
+    let buffer = bitfield.toBuffer({Jack: true, Kack: false, Lack: false, Mack: true, Nack: true, Oack: false, Pack: true, Quack: true});
+    assert.deepEqual(buffer, Buffer.from([JACK | MACK | PACK | NACK | QUACK]));
   });
 });

--- a/test/Boolean.js
+++ b/test/Boolean.js
@@ -1,55 +1,39 @@
-const {Boolean, uint8, DecodeStream, EncodeStream} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+import assert from 'assert';
+import {Boolean, uint8, DecodeStream, EncodeStream} from 'restructure';
 
 describe('Boolean', function() {
   describe('decode', function() {
     it('should decode 0 as false', function() {
-      const stream = new DecodeStream(Buffer.from([0]));
+      const buffer = new Uint8Array([0]);
       const boolean = new Boolean(uint8);
-      return boolean.decode(stream).should.equal(false);
+      assert.deepEqual(boolean.fromBuffer(buffer), false);
     });
 
-    return it('should decode 1 as true', function() {
-      const stream = new DecodeStream(Buffer.from([1]));
+    it('should decode 1 as true', function() {
+      const buffer = new Uint8Array([1]);
       const boolean = new Boolean(uint8);
-      return boolean.decode(stream).should.equal(true);
+      assert.deepEqual(boolean.fromBuffer(buffer), true);
     });
   });
 
   describe('size', () =>
     it('should return given type size', function() {
-      const stream = new DecodeStream(Buffer.from([0]));
       const boolean = new Boolean(uint8);
-      return boolean.size().should.equal(1);
+      assert.deepEqual(boolean.size(), 1);
     })
   );
 
-  return describe('encode', function() {
-    it('should encode false as 0', function(done) {
-      const stream = new EncodeStream;
+  describe('encode', function() {
+    it('should encode false as 0', function() {
       const boolean = new Boolean(uint8);
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0]));
-        return done();
-      })
-      );
-
-      boolean.encode(stream, false);
-      return stream.end();
+      const buffer = boolean.toBuffer(false);
+      assert.deepEqual(buffer, Buffer.from([0]));
     });
 
-    return it('should encode true as 1', function(done) {
-      const stream = new EncodeStream;
+    it('should encode true as 1', function() {
       const boolean = new Boolean(uint8);
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([1]));
-        return done();
-      })
-      );
-
-      boolean.encode(stream, true);
-      return stream.end();
+      const buffer = boolean.toBuffer(true);
+      assert.deepEqual(buffer, Buffer.from([1]));
     });
   });
 });

--- a/test/Buffer.js
+++ b/test/Buffer.js
@@ -1,62 +1,45 @@
-const {Buffer:BufferT, DecodeStream, EncodeStream, uint8} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+import assert from 'assert';
+import {Buffer as BufferT, uint8, DecodeStream, EncodeStream} from 'restructure';
 
 describe('Buffer', function() {
   describe('decode', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xab, 0xff, 0x1f, 0xb6]));
+      const buffer = new Uint8Array([0xab, 0xff]);
       const buf = new BufferT(2);
-      buf.decode(stream).should.deep.equal(Buffer.from([0xab, 0xff]));
-      return buf.decode(stream).should.deep.equal(Buffer.from([0x1f, 0xb6]));
+      assert.deepEqual(buf.fromBuffer(buffer), new Uint8Array([0xab, 0xff]));
   });
 
-    return it('should decode with parent key length', function() {
-      const stream = new DecodeStream(Buffer.from([0xab, 0xff, 0x1f, 0xb6]));
+    it('should decode with parent key length', function() {
+      const stream = new DecodeStream(new Uint8Array([0xab, 0xff, 0x1f, 0xb6]));
       const buf = new BufferT('len');
-      buf.decode(stream, {len: 3}).should.deep.equal(Buffer.from([0xab, 0xff, 0x1f]));
-      return buf.decode(stream, {len: 1}).should.deep.equal(Buffer.from([0xb6]));
+      assert.deepEqual(buf.decode(stream, {len: 3}), new Uint8Array([0xab, 0xff, 0x1f]));
+      assert.deepEqual(buf.decode(stream, {len: 1}), new Uint8Array([0xb6]));
   });
 });
 
   describe('size', function() {
     it('should return size', function() {
       const buf = new BufferT(2);
-      return buf.size(Buffer.from([0xab, 0xff])).should.equal(2);
+      assert.equal(buf.size(new Uint8Array([0xab, 0xff])), 2);
     });
 
-    return it('should use defined length if no value given', function() {
+    it('should use defined length if no value given', function() {
       const array = new BufferT(10);
-      return array.size().should.equal(10);
+      assert.equal(array.size(), 10);
     });
   });
 
-  return describe('encode', function() {
-    it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xab, 0xff, 0x1f, 0xb6]));
-        return done();
-      })
-      );
-
+  describe('encode', function() {
+    it('should encode', function() {
       const buf = new BufferT(2);
-      buf.encode(stream, Buffer.from([0xab, 0xff]));
-      buf.encode(stream, Buffer.from([0x1f, 0xb6]));
-      return stream.end();
+      const buffer = buf.toBuffer(new Uint8Array([0xab, 0xff]));
+      assert.deepEqual(buffer, new Uint8Array([0xab, 0xff]));
     });
 
-    return it('should encode length before buffer', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([2, 0xab, 0xff]));
-        return done();
-      })
-      );
-
+    it('should encode length before buffer', function() {
       const buf = new BufferT(uint8);
-      buf.encode(stream, Buffer.from([0xab, 0xff]));
-      return stream.end();
+      const buffer = buf.toBuffer(new Uint8Array([0xab, 0xff]));
+      assert.deepEqual(buffer, new Uint8Array([2, 0xab, 0xff]));
     });
   });
 });

--- a/test/DecodeStream.js
+++ b/test/DecodeStream.js
@@ -1,78 +1,78 @@
-const {DecodeStream} = require('../');
-const should = require('chai').should();
+import {DecodeStream} from 'restructure';
+import assert from 'assert';
 
 describe('DecodeStream', function() {
   it('should read a buffer', function() {
-    const buf = Buffer.from([1,2,3]);
+    const buf = new Uint8Array([1,2,3]);
     const stream = new DecodeStream(buf);
-    return stream.readBuffer(buf.length).should.deep.equal(Buffer.from([1,2,3]));
-});
+    assert.deepEqual(stream.readBuffer(buf.length), new Uint8Array([1,2,3]));
+  });
 
   it('should readUInt16BE', function() {
-    const buf = Buffer.from([0xab, 0xcd]);
+    const buf = new Uint8Array([0xab, 0xcd]);
     const stream = new DecodeStream(buf);
-    return stream.readUInt16BE().should.deep.equal(0xabcd);
+    assert.deepEqual(stream.readUInt16BE(), 0xabcd);
   });
 
   it('should readUInt16LE', function() {
-    const buf = Buffer.from([0xab, 0xcd]);
+    const buf = new Uint8Array([0xab, 0xcd]);
     const stream = new DecodeStream(buf);
-    return stream.readUInt16LE().should.deep.equal(0xcdab);
+    assert.deepEqual(stream.readUInt16LE(), 0xcdab);
   });
 
   it('should readUInt24BE', function() {
-    const buf = Buffer.from([0xab, 0xcd, 0xef]);
+    const buf = new Uint8Array([0xab, 0xcd, 0xef]);
     const stream = new DecodeStream(buf);
-    return stream.readUInt24BE().should.deep.equal(0xabcdef);
+    assert.deepEqual(stream.readUInt24BE(), 0xabcdef);
   });
 
   it('should readUInt24LE', function() {
-    const buf = Buffer.from([0xab, 0xcd, 0xef]);
+    const buf = new Uint8Array([0xab, 0xcd, 0xef]);
     const stream = new DecodeStream(buf);
-    return stream.readUInt24LE().should.deep.equal(0xefcdab);
+    assert.deepEqual(stream.readUInt24LE(), 0xefcdab);
   });
 
   it('should readInt24BE', function() {
-    const buf = Buffer.from([0xff, 0xab, 0x24]);
+    const buf = new Uint8Array([0xff, 0xab, 0x24]);
     const stream = new DecodeStream(buf);
-    return stream.readInt24BE().should.deep.equal(-21724);
+    assert.deepEqual(stream.readInt24BE(), -21724);
   });
 
   it('should readInt24LE', function() {
-    const buf = Buffer.from([0x24, 0xab, 0xff]);
+    const buf = new Uint8Array([0x24, 0xab, 0xff]);
     const stream = new DecodeStream(buf);
-    return stream.readInt24LE().should.deep.equal(-21724);
+    assert.deepEqual(stream.readInt24LE(), -21724);
   });
 
-  return describe('readString', function() {
+  describe('readString', function() {
     it('should decode ascii by default', function() {
       const buf = Buffer.from('some text', 'ascii');
       const stream = new DecodeStream(buf);
-      return stream.readString(buf.length).should.equal('some text');
+      assert.equal(stream.readString(buf.length), 'some text');
     });
 
     it('should decode ascii', function() {
       const buf = Buffer.from('some text', 'ascii');
       const stream = new DecodeStream(buf);
-      return stream.readString(buf.length, 'ascii').should.equal('some text');
+      assert.equal(stream.readString(buf.length, 'ascii'), 'some text');
     });
 
     it('should decode utf8', function() {
       const buf = Buffer.from('unicode! 👍', 'utf8');
       const stream = new DecodeStream(buf);
-      return stream.readString(buf.length, 'utf8').should.equal('unicode! 👍');
+      assert.equal(stream.readString(buf.length, 'utf8'), 'unicode! 👍');
     });
 
     it('should decode utf16le', function() {
       const buf = Buffer.from('unicode! 👍', 'utf16le');
       const stream = new DecodeStream(buf);
-      return stream.readString(buf.length, 'utf16le').should.equal('unicode! 👍');
+      assert.equal(stream.readString(buf.length, 'utf16le'), 'unicode! 👍');
     });
 
     it('should decode ucs2', function() {
       const buf = Buffer.from('unicode! 👍', 'ucs2');
       const stream = new DecodeStream(buf);
-      return stream.readString(buf.length, 'ucs2').should.equal('unicode! 👍');
+      assert.equal(stream.readString(buf.length, 'ucs2'), 'unicode! 👍');
     });
 
     it('should decode utf16be', function() {
@@ -84,18 +84,18 @@ describe('DecodeStream', function() {
       }
 
       const stream = new DecodeStream(buf);
-      return stream.readString(buf.length, 'utf16be').should.equal('unicode! 👍');
+      assert.equal(stream.readString(buf.length, 'utf16be'), 'unicode! 👍');
     });
 
     it('should decode macroman', function() {
-      const buf = Buffer.from([0x8a, 0x63, 0x63, 0x65, 0x6e, 0x74, 0x65, 0x64, 0x20, 0x63, 0x68, 0x87, 0x72, 0x61, 0x63, 0x74, 0x65, 0x72, 0x73]);
+      const buf = new Uint8Array([0x8a, 0x63, 0x63, 0x65, 0x6e, 0x74, 0x65, 0x64, 0x20, 0x63, 0x68, 0x87, 0x72, 0x61, 0x63, 0x74, 0x65, 0x72, 0x73]);
       const stream = new DecodeStream(buf);
-      return stream.readString(buf.length, 'mac').should.equal('äccented cháracters');
+      assert.equal(stream.readString(buf.length, 'mac'), 'äccented cháracters');
     });
 
-    return it('should return a buffer for unsupported encodings', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3]));
-      return stream.readString(3, 'unsupported').should.deep.equal(Buffer.from([1, 2, 3]));
+    it('should return a buffer for unsupported encodings', function() {
+      const stream = new DecodeStream(new Uint8Array([1, 2, 3]));
+      assert.deepEqual(stream.readString(3, 'unsupported'), new Uint8Array([1, 2, 3]));
   });
 });
 });

--- a/test/EncodeStream.js
+++ b/test/EncodeStream.js
@@ -1,184 +1,104 @@
-const {EncodeStream} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+import {EncodeStream} from 'restructure';
+import assert from 'assert';
 
 describe('EncodeStream', function() {
-  it('should write a buffer', function(done) {
-    const stream = new EncodeStream;
-    stream.pipe(concat(function(buf) {
-      buf.should.deep.equal(Buffer.from([1,2,3]));
-      return done();
-    })
-    );
-
-    stream.writeBuffer(Buffer.from([1,2,3]));
-    return stream.end();
+  it('should write a buffer', function() {
+    const stream = new EncodeStream(new Uint8Array(3));
+    stream.writeBuffer(new Uint8Array([1,2,3]));
+    assert.deepEqual(stream.buffer, new Uint8Array([1,2,3]));
   });
 
-  it('should writeUInt16BE', function(done) {
-    const stream = new EncodeStream;
-    stream.pipe(concat(function(buf) {
-      buf.should.deep.equal(Buffer.from([0xab, 0xcd]));
-      return done();
-    })
-    );
-
+  it('should writeUInt16BE', function() {
+    const stream = new EncodeStream(new Uint8Array(2));
     stream.writeUInt16BE(0xabcd);
-    return stream.end();
+    assert.deepEqual(stream.buffer, new Uint8Array([0xab, 0xcd]));
   });
 
-  it('should writeUInt16LE', function(done) {
-    const stream = new EncodeStream;
-    stream.pipe(concat(function(buf) {
-      buf.should.deep.equal(Buffer.from([0xab, 0xcd]));
-      return done();
-    })
-    );
-
+  it('should writeUInt16LE', function() {
+    const stream = new EncodeStream(new Uint8Array(2));
     stream.writeUInt16LE(0xcdab);
-    return stream.end();
+    assert.deepEqual(stream.buffer, new Uint8Array([0xab, 0xcd]));
   });
 
-  it('should writeUInt24BE', function(done) {
-    const stream = new EncodeStream;
-    stream.pipe(concat(function(buf) {
-      buf.should.deep.equal(Buffer.from([0xab, 0xcd, 0xef]));
-      return done();
-    })
-    );
-
+  it('should writeUInt24BE', function() {
+    const stream = new EncodeStream(new Uint8Array(3));
     stream.writeUInt24BE(0xabcdef);
-    return stream.end();
+    assert.deepEqual(stream.buffer, new Uint8Array([0xab, 0xcd, 0xef]));
   });
 
-  it('should writeUInt24LE', function(done) {
-    const stream = new EncodeStream;
-    stream.pipe(concat(function(buf) {
-      buf.should.deep.equal(Buffer.from([0xef, 0xcd, 0xab]));
-      return done();
-    })
-    );
-
+  it('should writeUInt24LE', function() {
+    const stream = new EncodeStream(new Uint8Array(3));
     stream.writeUInt24LE(0xabcdef);
-    return stream.end();
+    assert.deepEqual(stream.buffer, new Uint8Array([0xef, 0xcd, 0xab]));
   });
 
-  it('should writeInt24BE', function(done) {
-    const stream = new EncodeStream;
-    stream.pipe(concat(function(buf) {
-      buf.should.deep.equal(Buffer.from([0xff, 0xab, 0x24, 0xab, 0xcd, 0xef]));
-      return done();
-    })
-    );
-
+  it('should writeInt24BE', function() {
+    const stream = new EncodeStream(new Uint8Array(6));
     stream.writeInt24BE(-21724);
     stream.writeInt24BE(0xabcdef);
-    return stream.end();
+    assert.deepEqual(stream.buffer, new Uint8Array([0xff, 0xab, 0x24, 0xab, 0xcd, 0xef]));
   });
 
-  it('should writeInt24LE', function(done) {
-    const stream = new EncodeStream;
-    stream.pipe(concat(function(buf) {
-      buf.should.deep.equal(Buffer.from([0x24, 0xab, 0xff, 0xef, 0xcd, 0xab]));
-      return done();
-    })
-    );
-
+  it('should writeInt24LE', function() {
+    const stream = new EncodeStream(new Uint8Array(6));
     stream.writeInt24LE(-21724);
     stream.writeInt24LE(0xabcdef);
-    return stream.end();
+    assert.deepEqual(stream.buffer, new Uint8Array([0x24, 0xab, 0xff, 0xef, 0xcd, 0xab]));
   });
 
-  it('should fill', function(done) {
-    const stream = new EncodeStream;
-    stream.pipe(concat(function(buf) {
-      buf.should.deep.equal(Buffer.from([10, 10, 10, 10, 10]));
-      return done();
-    })
-    );
-
+  it('should fill', function() {
+    const stream = new EncodeStream(new Uint8Array(5));
     stream.fill(10, 5);
-    return stream.end();
+    assert.deepEqual(stream.buffer, new Uint8Array([10, 10, 10, 10, 10]));
   });
 
-  return describe('writeString', function() {
-    it('should encode ascii by default', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('some text', 'ascii'));
-        return done();
-      })
-      );
-
+  describe('writeString', function() {
+    it('should encode ascii by default', function() {
+      const expected = Buffer.from('some text', 'ascii');
+      const stream = new EncodeStream(new Uint8Array(expected.length));
       stream.writeString('some text');
-      return stream.end();
+      assert.deepEqual(stream.buffer, expected);
     });
 
-    it('should encode ascii', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('some text', 'ascii'));
-        return done();
-      })
-      );
-
-      stream.writeString('some text');
-      return stream.end();
+    it('should encode ascii', function() {
+      const expected = Buffer.from('some text', 'ascii');
+      const stream = new EncodeStream(new Uint8Array(expected.length));
+      stream.writeString('some text', 'ascii');
+      assert.deepEqual(stream.buffer, expected);
     });
 
-    it('should encode utf8', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('unicode! 👍', 'utf8'));
-        return done();
-      })
-      );
-
+    it('should encode utf8', function() {
+      const expected = Buffer.from('unicode! 👍', 'utf8');
+      const stream = new EncodeStream(new Uint8Array(expected.length));
       stream.writeString('unicode! 👍', 'utf8');
-      return stream.end();
+      assert.deepEqual(stream.buffer, expected);
     });
 
-    it('should encode utf16le', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('unicode! 👍', 'utf16le'));
-        return done();
-      })
-      );
-
+    it('should encode utf16le', function() {
+      const expected = Buffer.from('unicode! 👍', 'utf16le');
+      const stream = new EncodeStream(new Uint8Array(expected.length));
       stream.writeString('unicode! 👍', 'utf16le');
-      return stream.end();
+      assert.deepEqual(stream.buffer, expected);
     });
 
-    it('should encode ucs2', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('unicode! 👍', 'ucs2'));
-        return done();
-      })
-      );
-
+    it('should encode ucs2', function() {
+      const expected = Buffer.from('unicode! 👍', 'ucs2');
+      const stream = new EncodeStream(new Uint8Array(expected.length));
       stream.writeString('unicode! 👍', 'ucs2');
-      return stream.end();
+      assert.deepEqual(stream.buffer, expected);
     });
 
-    it('should encode utf16be', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(out) {
-        const buf = Buffer.from('unicode! 👍', 'utf16le');
-        for (let i = 0, end = buf.length - 1; i < end; i += 2) {
-          const byte = buf[i];
-          buf[i] = buf[i + 1];
-          buf[i + 1] = byte;
-        }
+    it('should encode utf16be', function() {
+      const expected = Buffer.from('unicode! 👍', 'utf16le');
+      for (let i = 0, end = expected.length - 1; i < end; i += 2) {
+        const byte = expected[i];
+        expected[i] = expected[i + 1];
+        expected[i + 1] = byte;
+      }
 
-        out.should.deep.equal(buf);
-        return done();
-      })
-      );
-
+      const stream = new EncodeStream(new Uint8Array(expected.length));
       stream.writeString('unicode! 👍', 'utf16be');
-      return stream.end();
+      assert.deepEqual(stream.buffer, expected);
     });
   });
 });

--- a/test/EncodeStream.js
+++ b/test/EncodeStream.js
@@ -180,18 +180,5 @@ describe('EncodeStream', function() {
       stream.writeString('unicode! 👍', 'utf16be');
       return stream.end();
     });
-
-    return it('should encode macroman', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(out) {
-        const buf = Buffer.from([0x8a, 0x63, 0x63, 0x65, 0x6e, 0x74, 0x65, 0x64, 0x20, 0x63, 0x68, 0x87, 0x72, 0x61, 0x63, 0x74, 0x65, 0x72, 0x73]);
-        out.should.deep.equal(buf);
-        return done();
-      })
-      );
-
-      stream.writeString('äccented cháracters', 'mac');
-      return stream.end();
-    });
   });
 });

--- a/test/Enum.js
+++ b/test/Enum.js
@@ -1,34 +1,24 @@
-const {Enum, uint8, DecodeStream, EncodeStream} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+import assert from 'assert';
+import {Enum, uint8, DecodeStream, EncodeStream} from 'restructure';
 
 describe('Enum', function() {
   const e = new Enum(uint8, ['foo', 'bar', 'baz']);
-  it('should have the right size', () => e.size().should.equal(1));
+  it('should have the right size', () => assert.equal(e.size(), 1));
 
   it('should decode', function() {
-    const stream = new DecodeStream(Buffer.from([1, 2, 0]));
-    e.decode(stream).should.equal('bar');
-    e.decode(stream).should.equal('baz');
-    return e.decode(stream).should.equal('foo');
+    const stream = new DecodeStream(new Uint8Array([1, 2, 0]));
+    assert.equal(e.decode(stream), 'bar');
+    assert.equal(e.decode(stream), 'baz');
+    assert.equal(e.decode(stream), 'foo');
   });
 
-  it('should encode', function(done) {
-    const stream = new EncodeStream;
-    stream.pipe(concat(function(buf) {
-      buf.should.deep.equal(Buffer.from([1, 2, 0]));
-      return done();
-    })
-    );
-
-    e.encode(stream, 'bar');
-    e.encode(stream, 'baz');
-    e.encode(stream, 'foo');
-    return stream.end();
+  it('should encode', function() {
+    assert.deepEqual(e.toBuffer('bar'), new Uint8Array([1]));
+    assert.deepEqual(e.toBuffer('baz'), new Uint8Array([2]));
+    assert.deepEqual(e.toBuffer('foo'), new Uint8Array([0]));
   });
 
-  return it('should throw on unknown option', function() {
-    const stream = new EncodeStream;
-    return should.throw(() => e.encode(stream, 'unknown'));
+  it('should throw on unknown option', function() {
+    return assert.throws(() => e.toBuffer('unknown'));
   });
 });

--- a/test/LazyArray.js
+++ b/test/LazyArray.js
@@ -30,14 +30,6 @@ describe('LazyArray', function() {
       return arr.toArray().should.deep.equal([1, 2, 3, 4]);
   });
 
-    it('should have an inspect method', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3, 4, 5]));
-      const array = new LazyArray(uint8, 4);
-
-      const arr = array.decode(stream);
-      return arr.inspect().should.equal('[ 1, 2, 3, 4 ]');
-    });
-
     return it('should decode length as number before array', function() {
       const stream = new DecodeStream(Buffer.from([4, 1, 2, 3, 4, 5]));
       const array = new LazyArray(uint8, uint8);

--- a/test/LazyArray.js
+++ b/test/LazyArray.js
@@ -1,69 +1,59 @@
-const {LazyArray, Pointer, uint8, uint16, DecodeStream, EncodeStream} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+import assert from 'assert';
+import {LazyArray, Pointer, uint8, uint16, DecodeStream, EncodeStream} from 'restructure';
 
 describe('LazyArray', function() {
   describe('decode', function() {
     it('should decode items lazily', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3, 4, 5]));
+      const stream = new DecodeStream(new Uint8Array([1, 2, 3, 4, 5]));
       const array = new LazyArray(uint8, 4);
 
       const arr = array.decode(stream);
-      arr.should.not.be.an.instanceof(Array);
-      arr.should.have.length(4);
-      stream.pos.should.equal(4);
+      assert(!(arr instanceof Array));
+      assert.equal(arr.length, 4);
+      assert.equal(stream.pos, 4);
 
-      arr.get(0).should.equal(1);
-      arr.get(1).should.equal(2);
-      arr.get(2).should.equal(3);
-      arr.get(3).should.equal(4);
+      assert.equal(arr.get(0), 1);
+      assert.equal(arr.get(1), 2);
+      assert.equal(arr.get(2), 3);
+      assert.equal(arr.get(3), 4);
 
-      should.not.exist(arr.get(-1));
-      return should.not.exist(arr.get(5));
+      assert.equal(arr.get(-1), null);
+      assert.equal(arr.get(5), null);
     });
 
     it('should be able to convert to an array', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3, 4, 5]));
+      const stream = new DecodeStream(new Uint8Array([1, 2, 3, 4, 5]));
       const array = new LazyArray(uint8, 4);
 
       const arr = array.decode(stream);
-      return arr.toArray().should.deep.equal([1, 2, 3, 4]);
-  });
+      assert.deepEqual(arr.toArray(), [1, 2, 3, 4]);
+    });
 
-    return it('should decode length as number before array', function() {
-      const stream = new DecodeStream(Buffer.from([4, 1, 2, 3, 4, 5]));
+    it('should decode length as number before array', function() {
+      const stream = new DecodeStream(new Uint8Array([4, 1, 2, 3, 4, 5]));
       const array = new LazyArray(uint8, uint8);
       const arr = array.decode(stream);
 
-      return arr.toArray().should.deep.equal([1, 2, 3, 4]);
+      assert.deepEqual(arr.toArray(), [1, 2, 3, 4]);
+    });
   });
-});
 
   describe('size', () =>
     it('should work with LazyArrays', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3, 4, 5]));
+      const stream = new DecodeStream(new Uint8Array([1, 2, 3, 4, 5]));
       const array = new LazyArray(uint8, 4);
       const arr = array.decode(stream);
 
-      return array.size(arr).should.equal(4);
+      assert.equal(array.size(arr), 4);
     })
   );
 
-  return describe('encode', () =>
-    it('should work with LazyArrays', function(done) {
-      const stream = new DecodeStream(Buffer.from([1, 2, 3, 4, 5]));
+  describe('encode', () =>
+    it('should work with LazyArrays', function() {
       const array = new LazyArray(uint8, 4);
-      const arr = array.decode(stream);
-
-      const enc = new EncodeStream;
-      enc.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([1, 2, 3, 4]));
-        return done();
-      })
-      );
-
-      array.encode(enc, arr);
-      return enc.end();
+      const arr = array.fromBuffer(new Uint8Array([1, 2, 3, 4, 5]));
+      const buffer = array.toBuffer(arr);
+      assert.deepEqual(buffer, new Uint8Array([1, 2, 3, 4]));
     })
   );
 });

--- a/test/Number.js
+++ b/test/Number.js
@@ -1,4 +1,4 @@
-const {
+import {
   uint8,
   uint16, uint16be, uint16le,
   uint24, uint24be, uint24le,
@@ -12,514 +12,345 @@ const {
   fixed16, fixed16be, fixed16le,
   fixed32, fixed32be, fixed32le,
   DecodeStream, EncodeStream
-} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+} from 'restructure';
+import assert from 'assert';
 
 describe('Number', function() {
   describe('uint8', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xab, 0xff]));
-      uint8.decode(stream).should.equal(0xab);
-      return uint8.decode(stream).should.equal(0xff);
+      const stream = new DecodeStream(new Uint8Array([0xab, 0xff]));
+      assert.equal(uint8.decode(stream), 0xab);
+      assert.equal(uint8.decode(stream), 0xff);
     });
 
-    it('should have a size', () => uint8.size().should.equal(1));
+    it('should have a size', () => assert.equal(uint8.size(), 1));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xab, 0xff]));
-        return done();
-      })
-      );
-
-      uint8.encode(stream, 0xab);
-      uint8.encode(stream, 0xff);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(uint8.toBuffer(0xab), new Uint8Array([0xab]));
+      assert.deepEqual(uint8.toBuffer(0xff), new Uint8Array([0xff]));
     });
   });
 
   describe('uint16', () =>
-    it('is an alias for uint16be', () => uint16.should.equal(uint16be))
+    it('is an alias for uint16be', () => assert.deepEqual(uint16, uint16be))
   );
 
   describe('uint16be', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xab, 0xff]));
-      return uint16be.decode(stream).should.equal(0xabff);
+      const stream = new DecodeStream(new Uint8Array([0xab, 0xff]));
+      assert.equal(uint16be.decode(stream), 0xabff);
     });
 
-    it('should have a size', () => uint16be.size().should.equal(2));
+    it('should have a size', () => assert.equal(uint16be.size(), 2));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xab, 0xff]));
-        return done();
-      })
-      );
-
-      uint16be.encode(stream, 0xabff);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(uint16be.toBuffer(0xabff), new Uint8Array([0xab, 0xff]));
     });
   });
 
   describe('uint16le', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xff, 0xab]));
-      return uint16le.decode(stream).should.equal(0xabff);
+      const stream = new DecodeStream(new Uint8Array([0xff, 0xab]));
+      assert.equal(uint16le.decode(stream), 0xabff);
     });
 
-    it('should have a size', () => uint16le.size().should.equal(2));
+    it('should have a size', () => assert.equal(uint16le.size(), 2));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xff, 0xab]));
-        return done();
-      })
-      );
-
-      uint16le.encode(stream, 0xabff);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(uint16le.toBuffer(0xabff), new Uint8Array([0xff, 0xab]));
     });
   });
 
   describe('uint24', () =>
-    it('is an alias for uint24be', () => uint24.should.equal(uint24be))
+    it('is an alias for uint24be', () => assert.deepEqual(uint24, uint24be))
   );
 
   describe('uint24be', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xff, 0xab, 0x24]));
-      return uint24be.decode(stream).should.equal(0xffab24);
+      const stream = new DecodeStream(new Uint8Array([0xff, 0xab, 0x24]));
+      assert.equal(uint24be.decode(stream), 0xffab24);
     });
 
-    it('should have a size', () => uint24be.size().should.equal(3));
+    it('should have a size', () => assert.equal(uint24be.size(), 3));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xff, 0xab, 0x24]));
-        return done();
-      })
-      );
-
-      uint24be.encode(stream, 0xffab24);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(uint24be.toBuffer(0xffab24), new Uint8Array([0xff, 0xab, 0x24]));
     });
   });
 
   describe('uint24le', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0x24, 0xab, 0xff]));
-      return uint24le.decode(stream).should.equal(0xffab24);
+      const stream = new DecodeStream(new Uint8Array([0x24, 0xab, 0xff]));
+      assert.equal(uint24le.decode(stream), 0xffab24);
     });
 
-    it('should have a size', () => uint24le.size().should.equal(3));
+    it('should have a size', () => assert.equal(uint24le.size(), 3));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0x24, 0xab, 0xff]));
-        return done();
-      })
-      );
-
-      uint24le.encode(stream, 0xffab24);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(uint24le.toBuffer(0xffab24), new Uint8Array([0x24, 0xab, 0xff]));
     });
   });
 
   describe('uint32', () =>
-    it('is an alias for uint32be', () => uint32.should.equal(uint32be))
+    it('is an alias for uint32be', () => assert.deepEqual(uint32, uint32be))
   );
 
   describe('uint32be', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xff, 0xab, 0x24, 0xbf]));
-      return uint32be.decode(stream).should.equal(0xffab24bf);
+      const stream = new DecodeStream(new Uint8Array([0xff, 0xab, 0x24, 0xbf]));
+      assert.equal(uint32be.decode(stream), 0xffab24bf);
     });
 
-    it('should have a size', () => uint32be.size().should.equal(4));
+    it('should have a size', () => assert.equal(uint32be.size(), 4));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xff, 0xab, 0x24, 0xbf]));
-        return done();
-      })
-      );
-
-      uint32be.encode(stream, 0xffab24bf);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(uint32be.toBuffer(0xffab24bf), new Uint8Array([0xff, 0xab, 0x24, 0xbf]));
     });
   });
 
   describe('uint32le', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xbf, 0x24, 0xab, 0xff]));
-      return uint32le.decode(stream).should.equal(0xffab24bf);
+      const stream = new DecodeStream(new Uint8Array([0xbf, 0x24, 0xab, 0xff]));
+      assert.equal(uint32le.decode(stream), 0xffab24bf);
     });
 
-    it('should have a size', () => uint32le.size().should.equal(4));
+    it('should have a size', () => assert.equal(uint32le.size(), 4));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xbf, 0x24, 0xab, 0xff]));
-        return done();
-      })
-      );
-
-      uint32le.encode(stream, 0xffab24bf);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(uint32le.toBuffer(0xffab24bf), new Uint8Array([0xbf, 0x24, 0xab, 0xff]));
     });
   });
 
   describe('int8', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0x7f, 0xff]));
-      int8.decode(stream).should.equal(127);
-      return int8.decode(stream).should.equal(-1);
+      const stream = new DecodeStream(new Uint8Array([0x7f, 0xff]));
+      assert.equal(int8.decode(stream), 127);
+      assert.equal(int8.decode(stream), -1);
     });
 
-    it('should have a size', () => int8.size().should.equal(1));
+    it('should have a size', () => assert.equal(int8.size(), 1));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0x7f, 0xff]));
-        return done();
-      })
-      );
-
-      int8.encode(stream, 127);
-      int8.encode(stream, -1);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(uint8.toBuffer(127), new Uint8Array([0x7f]));
+      assert.deepEqual(uint8.toBuffer(-1), new Uint8Array([0xff]));
     });
   });
 
   describe('int16', () =>
-    it('is an alias for int16be', () => int16.should.equal(int16be))
+    it('is an alias for int16be', () => assert.deepEqual(int16, int16be))
   );
 
   describe('int16be', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xff, 0xab]));
-      return int16be.decode(stream).should.equal(-85);
+      const stream = new DecodeStream(new Uint8Array([0xff, 0xab]));
+      assert.equal(int16be.decode(stream), -85);
     });
 
-    it('should have a size', () => int16be.size().should.equal(2));
+    it('should have a size', () => assert.equal(int16be.size(), 2));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xff, 0xab]));
-        return done();
-      })
-      );
-
-      int16be.encode(stream, -85);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(int16be.toBuffer(-85), new Uint8Array([0xff, 0xab]));
     });
   });
 
   describe('int16le', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xab, 0xff]));
-      return int16le.decode(stream).should.equal(-85);
+      const stream = new DecodeStream(new Uint8Array([0xab, 0xff]));
+      assert.equal(int16le.decode(stream), -85);
     });
 
-    it('should have a size', () => int16le.size().should.equal(2));
+    it('should have a size', () => assert.equal(int16le.size(), 2));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xab, 0xff]));
-        return done();
-      })
-      );
-
-      int16le.encode(stream, -85);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(int16le.toBuffer(-85), new Uint8Array([0xab, 0xff]));
     });
   });
 
   describe('int24', () =>
-    it('is an alias for int24be', () => int24.should.equal(int24be))
+    it('is an alias for int24be', () => assert.deepEqual(int24, int24be))
   );
 
   describe('int24be', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xff, 0xab, 0x24]));
-      return int24be.decode(stream).should.equal(-21724);
+      const stream = new DecodeStream(new Uint8Array([0xff, 0xab, 0x24]));
+      assert.equal(int24be.decode(stream), -21724);
     });
 
-    it('should have a size', () => int24be.size().should.equal(3));
+    it('should have a size', () => assert.equal(int24be.size(), 3));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xff, 0xab, 0x24]));
-        return done();
-      })
-      );
-
-      int24be.encode(stream, -21724);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(int24be.toBuffer(-21724), new Uint8Array([0xff, 0xab, 0x24]));
     });
   });
 
   describe('int24le', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0x24, 0xab, 0xff]));
-      return int24le.decode(stream).should.equal(-21724);
+      const stream = new DecodeStream(new Uint8Array([0x24, 0xab, 0xff]));
+      assert.equal(int24le.decode(stream), -21724);
     });
 
-    it('should have a size', () => int24le.size().should.equal(3));
+    it('should have a size', () => assert.equal(int24le.size(), 3));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0x24, 0xab, 0xff]));
-        return done();
-      })
-      );
-
-      int24le.encode(stream, -21724);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(int24le.toBuffer(-21724), new Uint8Array([0x24, 0xab, 0xff]));
     });
   });
 
   describe('int32', () =>
-    it('is an alias for int32be', () => int32.should.equal(int32be))
+    it('is an alias for int32be', () => assert.deepEqual(int32, int32be))
   );
 
   describe('int32be', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xff, 0xab, 0x24, 0xbf]));
-      return int32be.decode(stream).should.equal(-5561153);
+      const stream = new DecodeStream(new Uint8Array([0xff, 0xab, 0x24, 0xbf]));
+      assert.equal(int32be.decode(stream), -5561153);
     });
 
-    it('should have a size', () => int32be.size().should.equal(4));
+    it('should have a size', () => assert.equal(int32be.size(), 4));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xff, 0xab, 0x24, 0xbf]));
-        return done();
-      })
-      );
-
-      int32be.encode(stream, -5561153);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(int32be.toBuffer(-5561153), new Uint8Array([0xff, 0xab, 0x24, 0xbf]));
     });
   });
 
   describe('int32le', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xbf, 0x24, 0xab, 0xff]));
-      return int32le.decode(stream).should.equal(-5561153);
+      const stream = new DecodeStream(new Uint8Array([0xbf, 0x24, 0xab, 0xff]));
+      assert.equal(int32le.decode(stream), -5561153);
     });
 
-    it('should have a size', () => int32le.size().should.equal(4));
+    it('should have a size', () => assert.equal(int32le.size(), 4));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xbf, 0x24, 0xab, 0xff]));
-        return done();
-      })
-      );
-
-      int32le.encode(stream, -5561153);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(int32le.toBuffer(-5561153), new Uint8Array([0xbf, 0x24, 0xab, 0xff]));
     });
   });
 
   describe('float', () =>
-    it('is an alias for floatbe', () => float.should.equal(floatbe))
+    it('is an alias for floatbe', () => assert.deepEqual(float, floatbe))
   );
 
   describe('floatbe', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0x43, 0x7a, 0x8c, 0xcd]));
-      return floatbe.decode(stream).should.be.closeTo(250.55, 0.005);
+      const value = floatbe.fromBuffer(new Uint8Array([0x43, 0x7a, 0x8c, 0xcd]));
+      assert(value >= 250.55 - 0.005);
+      assert(value <= 250.55 + 0.005);
     });
 
-    it('should have a size', () => floatbe.size().should.equal(4));
+    it('should have a size', () => assert.equal(floatbe.size(), 4));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0x43, 0x7a, 0x8c, 0xcd]));
-        return done();
-      })
-      );
-
-      floatbe.encode(stream, 250.55);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(floatbe.toBuffer(250.55), new Uint8Array([0x43, 0x7a, 0x8c, 0xcd]));
     });
   });
 
   describe('floatle', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xcd, 0x8c, 0x7a, 0x43]));
-      return floatle.decode(stream).should.be.closeTo(250.55, 0.005);
+      const value = floatle.fromBuffer(new Uint8Array([0xcd, 0x8c, 0x7a, 0x43]));
+      assert(value >= 250.55 - 0.005);
+      assert(value <= 250.55 + 0.005);
     });
 
-    it('should have a size', () => floatle.size().should.equal(4));
+    it('should have a size', () => assert.equal(floatle.size(), 4));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xcd, 0x8c, 0x7a, 0x43]));
-        return done();
-      })
-      );
-
-      floatle.encode(stream, 250.55);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(floatle.toBuffer(250.55), new Uint8Array([0xcd, 0x8c, 0x7a, 0x43]));
     });
   });
 
   describe('double', () =>
-    it('is an alias for doublebe', () => double.should.equal(doublebe))
+    it('is an alias for doublebe', () => assert.deepEqual(double, doublebe))
   );
 
   describe('doublebe', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0x40, 0x93, 0x4a, 0x3d, 0x70, 0xa3, 0xd7, 0x0a]));
-      return doublebe.decode(stream).should.be.equal(1234.56);
+      const value = doublebe.fromBuffer(new Uint8Array([0x40, 0x93, 0x4a, 0x3d, 0x70, 0xa3, 0xd7, 0x0a]));
+      assert(value >= 1234.56 - 0.005);
+      assert(value <= 1234.56 + 0.005);
     });
 
-    it('should have a size', () => doublebe.size().should.equal(8));
+    it('should have a size', () => assert.equal(doublebe.size(), 8));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0x40, 0x93, 0x4a, 0x3d, 0x70, 0xa3, 0xd7, 0x0a]));
-        return done();
-      })
-      );
-
-      doublebe.encode(stream, 1234.56);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(doublebe.toBuffer(1234.56), new Uint8Array([0x40, 0x93, 0x4a, 0x3d, 0x70, 0xa3, 0xd7, 0x0a]));
     });
   });
 
   describe('doublele', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0x0a, 0xd7, 0xa3, 0x70, 0x3d, 0x4a, 0x93, 0x40]));
-      return doublele.decode(stream).should.be.equal(1234.56);
+      const value = doublele.fromBuffer(new Uint8Array([0x0a, 0xd7, 0xa3, 0x70, 0x3d, 0x4a, 0x93, 0x40]));
+      assert(value >= 1234.56 - 0.005);
+      assert(value <= 1234.56 + 0.005);
     });
 
-    it('should have a size', () => doublele.size().should.equal(8));
+    it('should have a size', () => assert.equal(doublele.size(), 8));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0x0a, 0xd7, 0xa3, 0x70, 0x3d, 0x4a, 0x93, 0x40]));
-        return done();
-      })
-      );
-
-      doublele.encode(stream, 1234.56);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(doublele.toBuffer(1234.56), new Uint8Array([0x0a, 0xd7, 0xa3, 0x70, 0x3d, 0x4a, 0x93, 0x40]));
     });
   });
 
   describe('fixed16', () =>
-    it('is an alias for fixed16be', () => fixed16.should.equal(fixed16be))
+    it('is an alias for fixed16be', () => assert.deepEqual(fixed16, fixed16be))
   );
 
   describe('fixed16be', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0x19, 0x57]));
-      return fixed16be.decode(stream).should.be.closeTo(25.34, 0.005);
+      const value = fixed16be.fromBuffer(new Uint8Array([0x19, 0x57]));
+      assert(value >= 25.34 - 0.005);
+      assert(value <= 25.34 + 0.005);
     });
 
-    it('should have a size', () => fixed16be.size().should.equal(2));
+    it('should have a size', () => assert.equal(fixed16be.size(), 2));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0x19, 0x57]));
-        return done();
-      })
-      );
-
-      fixed16be.encode(stream, 25.34);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(fixed16be.toBuffer(25.34), new Uint8Array([0x19, 0x57]));
     });
   });
 
   describe('fixed16le', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0x57, 0x19]));
-      return fixed16le.decode(stream).should.be.closeTo(25.34, 0.005);
+      const value = fixed16le.fromBuffer(new Uint8Array([0x57, 0x19]));
+      assert(value >= 25.34 - 0.005);
+      assert(value <= 25.34 + 0.005);
     });
 
-    it('should have a size', () => fixed16le.size().should.equal(2));
+    it('should have a size', () => assert.equal(fixed16le.size(), 2));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0x57, 0x19]));
-        return done();
-      })
-      );
-
-      fixed16le.encode(stream, 25.34);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(fixed16le.toBuffer(25.34), new Uint8Array([0x57, 0x19]));
     });
   });
 
   describe('fixed32', () =>
-    it('is an alias for fixed32be', () => fixed32.should.equal(fixed32be))
+    it('is an alias for fixed32be', () => assert.deepEqual(fixed32, fixed32be))
   );
 
   describe('fixed32be', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0x00, 0xfa, 0x8c, 0xcc]));
-      return fixed32be.decode(stream).should.be.closeTo(250.55, 0.005);
+      const value = fixed32be.fromBuffer(new Uint8Array([0x00, 0xfa, 0x8c, 0xcc]));
+      assert(value >= 250.55 - 0.005);
+      assert(value <= 250.55 + 0.005);
     });
 
-    it('should have a size', () => fixed32be.size().should.equal(4));
+    it('should have a size', () => assert.equal(fixed32be.size(), 4));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0x00, 0xfa, 0x8c, 0xcc]));
-        return done();
-      })
-      );
-
-      fixed32be.encode(stream, 250.55);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(fixed32be.toBuffer(250.55), new Uint8Array([0x00, 0xfa, 0x8c, 0xcc]));
     });
   });
 
-  return describe('fixed32le', function() {
+  describe('fixed32le', function() {
     it('should decode', function() {
-      const stream = new DecodeStream(Buffer.from([0xcc, 0x8c, 0xfa, 0x00]));
-      return fixed32le.decode(stream).should.be.closeTo(250.55, 0.005);
+      const value = fixed32le.fromBuffer(new Uint8Array([0xcc, 0x8c, 0xfa, 0x00]));
+      assert(value >= 250.55 - 0.005);
+      assert(value <= 250.55 + 0.005);
     });
 
-    it('should have a size', () => fixed32le.size().should.equal(4));
+    it('should have a size', () => assert.equal(fixed32le.size(), 4));
 
-    return it('should encode', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0xcc, 0x8c, 0xfa, 0x00]));
-        return done();
-      })
-      );
-
-      fixed32le.encode(stream, 250.55);
-      return stream.end();
+    it('should encode', function() {
+      assert.deepEqual(fixed32le.toBuffer(250.55), new Uint8Array([0xcc, 0x8c, 0xfa, 0x00]));
     });
   });
 });

--- a/test/Optional.js
+++ b/test/Optional.js
@@ -1,141 +1,100 @@
-const {Optional, uint8, DecodeStream, EncodeStream} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+import assert from 'assert';
+import {Optional, uint8, DecodeStream, EncodeStream} from 'restructure';
 
 describe('Optional', function() {
   describe('decode', function() {
     it('should not decode when condition is falsy', function() {
-      const stream = new DecodeStream(Buffer.from([0]));
+      const stream = new DecodeStream(new Uint8Array([0]));
       const optional = new Optional(uint8, false);
-      should.not.exist(optional.decode(stream));
-      return stream.pos.should.equal(0);
+      assert.equal(optional.decode(stream), null);
+      assert.equal(stream.pos, 0);
     });
 
     it('should not decode when condition is a function and falsy', function() {
-      const stream = new DecodeStream(Buffer.from([0]));
+      const stream = new DecodeStream(new Uint8Array([0]));
       const optional = new Optional(uint8, function() { return false; });
-      should.not.exist(optional.decode(stream));
-      return stream.pos.should.equal(0);
+      assert.equal(optional.decode(stream), null);
+      assert.equal(stream.pos, 0);
     });
 
     it('should decode when condition is omitted', function() {
-      const stream = new DecodeStream(Buffer.from([0]));
+      const stream = new DecodeStream(new Uint8Array([0]));
       const optional = new Optional(uint8);
-      should.exist(optional.decode(stream));
-      return stream.pos.should.equal(1);
+      assert(optional.decode(stream) != null);
+      assert.equal(stream.pos, 1);
     });
 
     it('should decode when condition is truthy', function() {
-      const stream = new DecodeStream(Buffer.from([0]));
+      const stream = new DecodeStream(new Uint8Array([0]));
       const optional = new Optional(uint8, true);
-      should.exist(optional.decode(stream));
-      return stream.pos.should.equal(1);
+      assert(optional.decode(stream) != null);
+      assert.equal(stream.pos, 1);
     });
 
-    return it('should decode when condition is a function and truthy', function() {
-      const stream = new DecodeStream(Buffer.from([0]));
+    it('should decode when condition is a function and truthy', function() {
+      const stream = new DecodeStream(new Uint8Array([0]));
       const optional = new Optional(uint8, function() { return true; });
-      should.exist(optional.decode(stream));
-      return stream.pos.should.equal(1);
+      assert(optional.decode(stream) != null);
+      assert.equal(stream.pos, 1);
     });
   });
 
   describe('size', function() {
     it('should return 0 when condition is falsy', function() {
-      const stream = new DecodeStream(Buffer.from([0]));
+      const stream = new DecodeStream(new Uint8Array([0]));
       const optional = new Optional(uint8, false);
-      return optional.size().should.equal(0);
+      assert.equal(optional.size(), 0);
     });
 
     it('should return 0 when condition is a function and falsy', function() {
-      const stream = new DecodeStream(Buffer.from([0]));
+      const stream = new DecodeStream(new Uint8Array([0]));
       const optional = new Optional(uint8, function() { return false; });
-      return optional.size().should.equal(0);
+      assert.equal(optional.size(), 0);
     });
 
     it('should return given type size when condition is omitted', function() {
-      const stream = new DecodeStream(Buffer.from([0]));
+      const stream = new DecodeStream(new Uint8Array([0]));
       const optional = new Optional(uint8);
-      return optional.size().should.equal(1);
+      assert.equal(optional.size(), 1);
     });
 
     it('should return given type size when condition is truthy', function() {
-      const stream = new DecodeStream(Buffer.from([0]));
+      const stream = new DecodeStream(new Uint8Array([0]));
       const optional = new Optional(uint8, true);
-      return optional.size().should.equal(1);
+      assert.equal(optional.size(), 1);
     });
 
-    return it('should return given type size when condition is a function and truthy', function() {
-      const stream = new DecodeStream(Buffer.from([0]));
+    it('should return given type size when condition is a function and truthy', function() {
+      const stream = new DecodeStream(new Uint8Array([0]));
       const optional = new Optional(uint8, function() { return true; });
-      return optional.size().should.equal(1);
+      assert.equal(optional.size(), 1);
     });
   });
 
-  return describe('encode', function() {
-    it('should not encode when condition is falsy', function(done) {
-      const stream = new EncodeStream;
+  describe('encode', function() {
+    it('should not encode when condition is falsy', function() {
       const optional = new Optional(uint8, false);
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal([]);
-        return done();
-      })
-      );
-
-      optional.encode(stream, 128);
-      return stream.end();
+      assert.deepEqual(optional.toBuffer(128), new Uint8Array(0));
     });
 
-    it('should not encode when condition is a function and falsy', function(done) {
-      const stream = new EncodeStream;
+    it('should not encode when condition is a function and falsy', function() {
       const optional = new Optional(uint8, function() { return false; });
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal([]);
-        return done();
-      })
-      );
-
-      optional.encode(stream, 128);
-      return stream.end();
+      assert.deepEqual(optional.toBuffer(128), new Uint8Array(0));
     });
 
-    it('should encode when condition is omitted', function(done) {
-      const stream = new EncodeStream;
+    it('should encode when condition is omitted', function() {
       const optional = new Optional(uint8);
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([128]));
-        return done();
-      })
-      );
-
-      optional.encode(stream, 128);
-      return stream.end();
+      assert.deepEqual(optional.toBuffer(128), new Uint8Array([128]));
     });
 
-    it('should encode when condition is truthy', function(done) {
-      const stream = new EncodeStream;
+    it('should encode when condition is truthy', function() {
       const optional = new Optional(uint8, true);
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([128]));
-        return done();
-      })
-      );
-
-      optional.encode(stream, 128);
-      return stream.end();
+      assert.deepEqual(optional.toBuffer(128), new Uint8Array([128]));
     });
 
-    return it('should encode when condition is a function and truthy', function(done) {
-      const stream = new EncodeStream;
+    it('should encode when condition is a function and truthy', function() {
       const optional = new Optional(uint8, function() { return true; });
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([128]));
-        return done();
-      })
-      );
-
-      optional.encode(stream, 128);
-      return stream.end();
+      assert.deepEqual(optional.toBuffer(128), new Uint8Array([128]));
     });
   });
 });

--- a/test/Pointer.js
+++ b/test/Pointer.js
@@ -1,66 +1,65 @@
-const {Pointer, VoidPointer, uint8, DecodeStream, EncodeStream, Struct} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+import assert from 'assert';
+import {Pointer, VoidPointer, uint8, DecodeStream, EncodeStream, Struct} from 'restructure';
 
 describe('Pointer', function() {
   describe('decode', function() {
     it('should handle null pointers', function() {
-      const stream = new DecodeStream(Buffer.from([0]));
+      const stream = new DecodeStream(new Uint8Array([0]));
       const pointer = new Pointer(uint8, uint8);
-      return should.not.exist(pointer.decode(stream, {_startOffset: 50}));
+      return assert.equal(pointer.decode(stream, {_startOffset: 50}), null);
     });
 
     it('should use local offsets from start of parent by default', function() {
-      const stream = new DecodeStream(Buffer.from([1, 53]));
+      const stream = new DecodeStream(new Uint8Array([1, 53]));
       const pointer = new Pointer(uint8, uint8);
-      return pointer.decode(stream, {_startOffset: 0}).should.equal(53);
+      assert.equal(pointer.decode(stream, {_startOffset: 0}), 53);
     });
 
     it('should support immediate offsets', function() {
-      const stream = new DecodeStream(Buffer.from([1, 53]));
+      const stream = new DecodeStream(new Uint8Array([1, 53]));
       const pointer = new Pointer(uint8, uint8, {type: 'immediate'});
-      return pointer.decode(stream).should.equal(53);
+      assert.equal(pointer.decode(stream), 53);
     });
 
     it('should support offsets relative to the parent', function() {
-      const stream = new DecodeStream(Buffer.from([0, 0, 1, 53]));
+      const stream = new DecodeStream(new Uint8Array([0, 0, 1, 53]));
       stream.pos = 2;
       const pointer = new Pointer(uint8, uint8, {type: 'parent'});
-      return pointer.decode(stream, {parent: {_startOffset: 2}}).should.equal(53);
+      assert.equal(pointer.decode(stream, {parent: {_startOffset: 2}}), 53);
     });
 
     it('should support global offsets', function() {
-      const stream = new DecodeStream(Buffer.from([1, 2, 4, 0, 0, 0, 53]));
+      const stream = new DecodeStream(new Uint8Array([1, 2, 4, 0, 0, 0, 53]));
       const pointer = new Pointer(uint8, uint8, {type: 'global'});
       stream.pos = 2;
-      return pointer.decode(stream, {parent: {parent: {_startOffset: 2}}}).should.equal(53);
+      assert.equal(pointer.decode(stream, {parent: {parent: {_startOffset: 2}}}), 53);
     });
 
     it('should support offsets relative to a property on the parent', function() {
-      const stream = new DecodeStream(Buffer.from([1, 0, 0, 0, 0, 53]));
+      const stream = new DecodeStream(new Uint8Array([1, 0, 0, 0, 0, 53]));
       const pointer = new Pointer(uint8, uint8, {relativeTo: ctx => ctx.parent.ptr});
-      return pointer.decode(stream, {_startOffset: 0, parent: {ptr: 4}}).should.equal(53);
+      assert.equal(pointer.decode(stream, {_startOffset: 0, parent: {ptr: 4}}), 53);
     });
 
     it('should throw when passing a non function relativeTo option', function() {
-      return should.throw(() => new Pointer(uint8, uint8, {relativeTo: 'parent.ptr'}));
+      return assert.throws(() => new Pointer(uint8, uint8, {relativeTo: 'parent.ptr'}));
     });
 
     it('should support returning pointer if there is no decode type', function() {
-      const stream = new DecodeStream(Buffer.from([4]));
+      const stream = new DecodeStream(new Uint8Array([4]));
       const pointer = new Pointer(uint8, 'void');
-      return pointer.decode(stream, {_startOffset: 0}).should.equal(4);
+      assert.equal(pointer.decode(stream, {_startOffset: 0}), 4);
     });
 
-    return it('should support decoding pointers lazily', function() {
-      const stream = new DecodeStream(Buffer.from([1, 53]));
+    it('should support decoding pointers lazily', function() {
+      const stream = new DecodeStream(new Uint8Array([1, 53]));
       const struct = new Struct({
         ptr: new Pointer(uint8, uint8, {lazy: true})});
 
       const res = struct.decode(stream);
-      Object.getOwnPropertyDescriptor(res, 'ptr').get.should.be.a('function');
-      Object.getOwnPropertyDescriptor(res, 'ptr').enumerable.should.equal(true);
-      return res.ptr.should.equal(53);
+      assert.equal(typeof Object.getOwnPropertyDescriptor(res, 'ptr').get, 'function');
+      assert.equal(Object.getOwnPropertyDescriptor(res, 'ptr').enumerable, true);
+      assert.equal(res.ptr, 53);
     });
   });
 
@@ -68,59 +67,52 @@ describe('Pointer', function() {
     it('should add to local pointerSize', function() {
       const pointer = new Pointer(uint8, uint8);
       const ctx = {pointerSize: 0};
-      pointer.size(10, ctx).should.equal(1);
-      return ctx.pointerSize.should.equal(1);
+      assert.equal(pointer.size(10, ctx), 1);
+      assert.equal(ctx.pointerSize, 1);
     });
 
     it('should add to immediate pointerSize', function() {
       const pointer = new Pointer(uint8, uint8, {type: 'immediate'});
       const ctx = {pointerSize: 0};
-      pointer.size(10, ctx).should.equal(1);
-      return ctx.pointerSize.should.equal(1);
+      assert.equal(pointer.size(10, ctx), 1);
+      assert.equal(ctx.pointerSize, 1);
     });
 
     it('should add to parent pointerSize', function() {
       const pointer = new Pointer(uint8, uint8, {type: 'parent'});
       const ctx = {parent: {pointerSize: 0}};
-      pointer.size(10, ctx).should.equal(1);
-      return ctx.parent.pointerSize.should.equal(1);
+      assert.equal(pointer.size(10, ctx), 1);
+      assert.equal(ctx.parent.pointerSize, 1);
     });
 
     it('should add to global pointerSize', function() {
       const pointer = new Pointer(uint8, uint8, {type: 'global'});
       const ctx = {parent: {parent: {parent: {pointerSize: 0}}}};
-      pointer.size(10, ctx).should.equal(1);
-      return ctx.parent.parent.parent.pointerSize.should.equal(1);
+      assert.equal(pointer.size(10, ctx), 1);
+      assert.equal(ctx.parent.parent.parent.pointerSize, 1);
     });
 
     it('should handle void pointers', function() {
       const pointer = new Pointer(uint8, 'void');
       const ctx = {pointerSize: 0};
-      pointer.size(new VoidPointer(uint8, 50), ctx).should.equal(1);
-      return ctx.pointerSize.should.equal(1);
+      assert.equal(pointer.size(new VoidPointer(uint8, 50), ctx), 1);
+      assert.equal(ctx.pointerSize, 1);
     });
 
     it('should throw if no type and not a void pointer', function() {
       const pointer = new Pointer(uint8, 'void');
       const ctx = {pointerSize: 0};
-      return should.throw(() => pointer.size(30, ctx).should.equal(1));
+      assert.throws(() => pointer.size(30, ctx));
     });
 
-    return it('should return a fixed size without a value', function() {
+    it('should return a fixed size without a value', function() {
       const pointer = new Pointer(uint8, uint8);
-      return pointer.size().should.equal(1);
+      assert.equal(pointer.size(), 1);
     });
   });
 
-  return describe('encode', function() {
-    it('should handle null pointers', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0]));
-        return done();
-      })
-      );
-
+  describe('encode', function() {
+    it('should handle null pointers', function() {
       const ptr = new Pointer(uint8, uint8);
       const ctx = {
         pointerSize: 0,
@@ -129,20 +121,14 @@ describe('Pointer', function() {
         pointers: []
       };
 
+      const stream = new EncodeStream(new Uint8Array(ptr.size(null)));
       ptr.encode(stream, null, ctx);
-      ctx.pointerSize.should.equal(0);
+      assert.equal(ctx.pointerSize, 0);
 
-      return stream.end();
+      assert.deepEqual(stream.buffer, new Uint8Array([0]));
     });
 
-    it('should handle local offsets', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([1]));
-        return done();
-      })
-      );
-
+    it('should handle local offsets', function() {
       const ptr = new Pointer(uint8, uint8);
       const ctx = {
         pointerSize: 0,
@@ -151,23 +137,17 @@ describe('Pointer', function() {
         pointers: []
       };
 
+      const stream = new EncodeStream(new Uint8Array(ptr.size(10)));
       ptr.encode(stream, 10, ctx);
-      ctx.pointerOffset.should.equal(2);
-      ctx.pointers.should.deep.equal([
+      assert.equal(ctx.pointerOffset, 2);
+      assert.deepEqual(ctx.pointers, [
         { type: uint8, val: 10, parent: ctx }
       ]);
 
-      return stream.end();
+      assert.deepEqual(stream.buffer, new Uint8Array([1]));
     });
 
-    it('should handle immediate offsets', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0]));
-        return done();
-      })
-      );
-
+    it('should handle immediate offsets', function() {
       const ptr = new Pointer(uint8, uint8, {type: 'immediate'});
       const ctx = {
         pointerSize: 0,
@@ -176,23 +156,17 @@ describe('Pointer', function() {
         pointers: []
       };
 
+      const stream = new EncodeStream(new Uint8Array(ptr.size(10)));
       ptr.encode(stream, 10, ctx);
-      ctx.pointerOffset.should.equal(2);
-      ctx.pointers.should.deep.equal([
+      assert.equal(ctx.pointerOffset, 2);
+      assert.deepEqual(ctx.pointers, [
         { type: uint8, val: 10, parent: ctx }
       ]);
 
-      return stream.end();
+      assert.deepEqual(stream.buffer, new Uint8Array([0]));
     });
 
-    it('should handle immediate offsets', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([0]));
-        return done();
-      })
-      );
-
+    it('should handle immediate offsets', function() {
       const ptr = new Pointer(uint8, uint8, {type: 'immediate'});
       const ctx = {
         pointerSize: 0,
@@ -201,23 +175,17 @@ describe('Pointer', function() {
         pointers: []
       };
 
+      const stream = new EncodeStream(new Uint8Array(ptr.size(10)));
       ptr.encode(stream, 10, ctx);
-      ctx.pointerOffset.should.equal(2);
-      ctx.pointers.should.deep.equal([
+      assert.equal(ctx.pointerOffset, 2);
+      assert.deepEqual(ctx.pointers, [
         { type: uint8, val: 10, parent: ctx }
       ]);
 
-      return stream.end();
+      assert.deepEqual(stream.buffer, new Uint8Array([0]));
     });
 
-    it('should handle offsets relative to parent', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([2]));
-        return done();
-      })
-      );
-
+    it('should handle offsets relative to parent', function() {
       const ptr = new Pointer(uint8, uint8, {type: 'parent'});
       const ctx = {
         parent: {
@@ -228,23 +196,17 @@ describe('Pointer', function() {
         }
       };
 
+      const stream = new EncodeStream(new Uint8Array(ptr.size(10, {parent: {...ctx.parent}})));
       ptr.encode(stream, 10, ctx);
-      ctx.parent.pointerOffset.should.equal(6);
-      ctx.parent.pointers.should.deep.equal([
+      assert.equal(ctx.parent.pointerOffset, 6);
+      assert.deepEqual(ctx.parent.pointers, [
         { type: uint8, val: 10, parent: ctx }
       ]);
 
-      return stream.end();
+      assert.deepEqual(stream.buffer, new Uint8Array([2]));
     });
 
-    it('should handle global offsets', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([5]));
-        return done();
-      })
-      );
-
+    it('should handle global offsets', function() {
       const ptr = new Pointer(uint8, uint8, {type: 'global'});
       const ctx = {
         parent: {
@@ -259,23 +221,17 @@ describe('Pointer', function() {
         }
       };
 
+      const stream = new EncodeStream(new Uint8Array(ptr.size(10, JSON.parse(JSON.stringify(ctx)))));
       ptr.encode(stream, 10, ctx);
-      ctx.parent.parent.parent.pointerOffset.should.equal(6);
-      ctx.parent.parent.parent.pointers.should.deep.equal([
+      assert.equal(ctx.parent.parent.parent.pointerOffset, 6);
+      assert.deepEqual(ctx.parent.parent.parent.pointers, [
         { type: uint8, val: 10, parent: ctx }
       ]);
 
-      return stream.end();
+      assert.deepEqual(stream.buffer, new Uint8Array([5]));
     });
 
-    it('should support offsets relative to a property on the parent', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([6]));
-        return done();
-      })
-      );
-
+    it('should support offsets relative to a property on the parent', function() {
       const ptr = new Pointer(uint8, uint8, {relativeTo: ctx => ctx.ptr});
       const ctx = {
         pointerSize: 0,
@@ -287,23 +243,17 @@ describe('Pointer', function() {
         }
       };
 
+      const stream = new EncodeStream(new Uint8Array(ptr.size(10, {...ctx})));
       ptr.encode(stream, 10, ctx);
-      ctx.pointerOffset.should.equal(11);
-      ctx.pointers.should.deep.equal([
+      assert.equal(ctx.pointerOffset, 11);
+      assert.deepEqual(ctx.pointers, [
         { type: uint8, val: 10, parent: ctx }
       ]);
 
-      return stream.end();
+      assert.deepEqual(stream.buffer, new Uint8Array([6]));
     });
 
-    it('should support void pointers', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from([1]));
-        return done();
-      })
-      );
-
+    it('should support void pointers', function() {
       const ptr = new Pointer(uint8, 'void');
       const ctx = {
         pointerSize: 0,
@@ -312,17 +262,18 @@ describe('Pointer', function() {
         pointers: []
       };
 
-      ptr.encode(stream, new VoidPointer(uint8, 55), ctx);
-      ctx.pointerOffset.should.equal(2);
-      ctx.pointers.should.deep.equal([
+      const val = new VoidPointer(uint8, 55);
+      const stream = new EncodeStream(new Uint8Array(ptr.size(val, {...ctx})));
+      ptr.encode(stream, val, ctx);
+      assert.equal(ctx.pointerOffset, 2);
+      assert.deepEqual(ctx.pointers, [
         { type: uint8, val: 55, parent: ctx }
       ]);
 
-      return stream.end();
+      assert.deepEqual(stream.buffer, new Uint8Array([1]));
     });
 
-    return it('should throw if not a void pointer instance', function() {
-      const stream = new EncodeStream;
+    it('should throw if not a void pointer instance', function() {
       const ptr = new Pointer(uint8, 'void');
       const ctx = {
         pointerSize: 0,
@@ -331,7 +282,8 @@ describe('Pointer', function() {
         pointers: []
       };
 
-      return should.throw(() => ptr.encode(stream, 44, ctx));
+      const stream = new EncodeStream(new Uint8Array(0));
+      assert.throws(() => ptr.encode(stream, 44, ctx));
     });
   });
 });

--- a/test/Reserved.js
+++ b/test/Reserved.js
@@ -1,35 +1,26 @@
-const {Reserved, uint8, uint16, DecodeStream, EncodeStream} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+import assert from 'assert';
+import {Reserved, uint8, uint16, DecodeStream, EncodeStream} from 'restructure';
 
 describe('Reserved', function() {
   it('should have a default count of 1', function() {
     const reserved = new Reserved(uint8);
-    return reserved.size().should.equal(1);
+    assert.equal(reserved.size(), 1);
   });
 
   it('should allow custom counts and types', function() {
     const reserved = new Reserved(uint16, 10);
-    return reserved.size().should.equal(20);
+    assert.equal(reserved.size(), 20);
   });
 
   it('should decode', function() {
-    const stream = new DecodeStream(Buffer.from([0, 0]));
+    const stream = new DecodeStream(new Uint8Array([0, 0]));
     const reserved = new Reserved(uint16);
-    should.not.exist(reserved.decode(stream));
-    return stream.pos.should.equal(2);
+    assert.equal(reserved.decode(stream), null);
+    assert.equal(stream.pos, 2);
   });
 
-  return it('should encode', function(done) {
-    const stream = new EncodeStream;
+  it('should encode', function() {
     const reserved = new Reserved(uint16);
-    stream.pipe(concat(function(buf) {
-      buf.should.deep.equal(Buffer.from([0, 0]));
-      return done();
-    })
-    );
-
-    reserved.encode(stream);
-    return stream.end();
+    assert.deepEqual(reserved.toBuffer(), new Uint8Array([0, 0]));
   });
 });

--- a/test/String.js
+++ b/test/String.js
@@ -1,167 +1,113 @@
-const {String:StringT, uint8, DecodeStream, EncodeStream} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+import assert from 'assert';
+import {String as StringT, uint8, DecodeStream, EncodeStream} from 'restructure';
 
 describe('String', function() {
   describe('decode', function() {
     it('should decode fixed length', function() {
-      const stream = new DecodeStream(Buffer.from('testing'));
       const string = new StringT(7);
-      return string.decode(stream).should.equal('testing');
+      assert.equal(string.fromBuffer(Buffer.from('testing')), 'testing');
     });
 
     it('should decode length from parent key', function() {
       const stream = new DecodeStream(Buffer.from('testing'));
       const string = new StringT('len');
-      return string.decode(stream, {len: 7}).should.equal('testing');
+      assert.equal(string.decode(stream, {len: 7}), 'testing');
     });
 
     it('should decode length as number before string', function() {
-      const stream = new DecodeStream(Buffer.from('\x07testing'));
       const string = new StringT(uint8);
-      return string.decode(stream).should.equal('testing');
+      assert.equal(string.fromBuffer(Buffer.from('\x07testing')), 'testing');
     });
 
     it('should decode utf8', function() {
-      const stream = new DecodeStream(Buffer.from('🍻'));
       const string = new StringT(4, 'utf8');
-      return string.decode(stream).should.equal('🍻');
+      assert.equal(string.fromBuffer(Buffer.from('🍻')), '🍻');
     });
 
     it('should decode encoding computed from function', function() {
-      const stream = new DecodeStream(Buffer.from('🍻'));
       const string = new StringT(4, function() { return 'utf8'; });
-      return string.decode(stream).should.equal('🍻');
+      assert.equal(string.fromBuffer(Buffer.from('🍻')), '🍻');
     });
 
     it('should decode null-terminated string and read past terminator', function() {
       const stream = new DecodeStream(Buffer.from('🍻\x00'));
       const string = new StringT(null, 'utf8');
-      string.decode(stream).should.equal('🍻');
-      return stream.pos.should.equal(5);
+      assert.equal(string.decode(stream), '🍻');
+      assert.equal(stream.pos, 5);
     });
 
-    return it('should decode remainder of buffer when null-byte missing', function() {
-      const stream = new DecodeStream(Buffer.from('🍻'));
+    it('should decode remainder of buffer when null-byte missing', function() {
       const string = new StringT(null, 'utf8');
-      return string.decode(stream).should.equal('🍻');
+      assert.equal(string.fromBuffer(Buffer.from('🍻')), '🍻');
     });
   });
 
   describe('size', function() {
     it('should use string length', function() {
       const string = new StringT(7);
-      return string.size('testing').should.equal(7);
+      assert.equal(string.size('testing'), 7);
     });
 
     it('should use correct encoding', function() {
       const string = new StringT(10, 'utf8');
-      return string.size('🍻').should.equal(4);
+      assert.equal(string.size('🍻'), 4);
     });
 
     it('should use encoding from function', function() {
       const string = new StringT(10, function() { return 'utf8'; });
-      return string.size('🍻').should.equal(4);
+      assert.equal(string.size('🍻'), 4);
     });
 
     it('should add size of length field before string', function() {
       const string = new StringT(uint8, 'utf8');
-      return string.size('🍻').should.equal(5);
+      assert.equal(string.size('🍻'), 5);
     });
 
     it('should work with utf16be encoding', function() {
       const string = new StringT(10, 'utf16be');
-      return string.size('🍻').should.equal(4);
+      assert.equal(string.size('🍻'), 4);
     });
 
     it('should take null-byte into account', function() {
       const string = new StringT(null, 'utf8');
-      return string.size('🍻').should.equal(5);
+      assert.equal(string.size('🍻'), 5);
     });
 
-    return it('should use defined length if no value given', function() {
+    it('should use defined length if no value given', function() {
       const array = new StringT(10);
-      return array.size().should.equal(10);
+      assert.equal(array.size(), 10);
     });
   });
 
-  return describe('encode', function() {
-    it('should encode using string length', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('testing'));
-        return done();
-      })
-      );
-
+  describe('encode', function() {
+    it('should encode using string length', function() {
       const string = new StringT(7);
-      string.encode(stream, 'testing');
-      return stream.end();
+      assert.deepEqual(string.toBuffer('testing'), Buffer.from('testing'));
     });
 
-    it('should encode length as number before string', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('\x07testing'));
-        return done();
-      })
-      );
-
+    it('should encode length as number before string', function() {
       const string = new StringT(uint8);
-      string.encode(stream, 'testing');
-      return stream.end();
+      assert.deepEqual(string.toBuffer('testing'), Buffer.from('\x07testing'));
     });
 
-    it('should encode length as number before string utf8', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('\x0ctesting 😜', 'utf8'));
-        return done();
-      })
-      );
-
+    it('should encode length as number before string utf8', function() {
       const string = new StringT(uint8, 'utf8');
-      string.encode(stream, 'testing 😜');
-      return stream.end();
+      assert.deepEqual(string.toBuffer('testing 😜'), Buffer.from('\x0ctesting 😜', 'utf8'));
     });
 
-    it('should encode utf8', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('🍻'));
-        return done();
-      })
-      );
-
+    it('should encode utf8', function() {
       const string = new StringT(4, 'utf8');
-      string.encode(stream, '🍻');
-      return stream.end();
+      assert.deepEqual(string.toBuffer('🍻'), Buffer.from('🍻'));
     });
 
-    it('should encode encoding computed from function', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('🍻'));
-        return done();
-      })
-      );
-
+    it('should encode encoding computed from function', function() {
       const string = new StringT(4, function() { return 'utf8'; });
-      string.encode(stream, '🍻');
-      return stream.end();
+      assert.deepEqual(string.toBuffer('🍻'), Buffer.from('🍻'));
     });
 
-    return it('should encode null-terminated string', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('🍻\x00'));
-        return done();
-      })
-      );
-
+    it('should encode null-terminated string', function() {
       const string = new StringT(null, 'utf8');
-      string.encode(stream, '🍻');
-      return stream.end();
+      assert.deepEqual(string.toBuffer('🍻'), Buffer.from('🍻\x00'));
     });
   });
 });

--- a/test/Struct.js
+++ b/test/Struct.js
@@ -1,24 +1,21 @@
-const {Struct, String:StringT, Pointer, uint8, DecodeStream, EncodeStream} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+import assert from 'assert';
+import {Struct, String as StringT, Pointer, uint8, DecodeStream, EncodeStream} from 'restructure';
 
 describe('Struct', function() {
   describe('decode', function() {
     it('should decode into an object', function() {
-      const stream = new DecodeStream(Buffer.from('\x05devon\x15'));
       const struct = new Struct({
         name: new StringT(uint8),
         age: uint8
       });
 
-      return struct.decode(stream).should.deep.equal({
+      assert.deepEqual(struct.fromBuffer(Buffer.from('\x05devon\x15')), {
         name: 'devon',
         age: 21
       });
     });
 
     it('should support process hook', function() {
-      const stream = new DecodeStream(Buffer.from('\x05devon\x20'));
       const struct = new Struct({
         name: new StringT(uint8),
         age: uint8
@@ -28,22 +25,21 @@ describe('Struct', function() {
         return this.canDrink = this.age >= 21;
       };
 
-      return struct.decode(stream).should.deep.equal({
+      assert.deepEqual(struct.fromBuffer(Buffer.from('\x05devon\x20')), {
         name: 'devon',
         age: 32,
         canDrink: true
       });
     });
 
-    return it('should support function keys', function() {
-      const stream = new DecodeStream(Buffer.from('\x05devon\x20'));
+    it('should support function keys', function() {
       const struct = new Struct({
         name: new StringT(uint8),
         age: uint8,
         canDrink() { return this.age >= 21; }
       });
 
-      return struct.decode(stream).should.deep.equal({
+      assert.deepEqual(struct.fromBuffer(Buffer.from('\x05devon\x20')), {
         name: 'devon',
         age: 32,
         canDrink: true
@@ -58,7 +54,7 @@ describe('Struct', function() {
         age: uint8
       });
 
-      return struct.size({name: 'devon', age: 21}).should.equal(7);
+      assert.equal(struct.size({name: 'devon', age: 21}), 7);
     });
 
     it('should compute the correct size with pointers', function() {
@@ -74,7 +70,7 @@ describe('Struct', function() {
         ptr: 'hello'
       });
 
-      return size.should.equal(14);
+      assert.equal(size, 14);
     });
 
     it('should get the correct size when no value is given', function() {
@@ -83,51 +79,35 @@ describe('Struct', function() {
         age: uint8
       });
 
-      return struct.size().should.equal(5);
+      assert.equal(struct.size(), 5);
     });
 
-    return it('should throw when getting non-fixed length size and no value is given', function() {
+    it('should throw when getting non-fixed length size and no value is given', function() {
       const struct = new Struct({
         name: new StringT(uint8),
         age: uint8
       });
 
-      return should.throw(() => struct.size()
-      , /not a fixed size/i);
+      assert.throws(() => struct.size(), /not a fixed size/i);
     });
   });
 
-  return describe('encode', function() {
-    it('should encode objects to buffers', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('\x05devon\x15'));
-        return done();
-      })
-      );
-
+  describe('encode', function() {
+    it('should encode objects to buffers', function() {
       const struct = new Struct({
         name: new StringT(uint8),
         age: uint8
       });
 
-      struct.encode(stream, {
+      const buf = struct.toBuffer({
         name: 'devon',
         age: 21
-      }
-      );
+      });
 
-      return stream.end();
+      assert.deepEqual(buf, Buffer.from('\x05devon\x15'));
     });
 
-    it('should support preEncode hook', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('\x05devon\x15'));
-        return done();
-      })
-      );
-
+    it('should support preEncode hook', function() {
       const struct = new Struct({
         nameLength: uint8,
         name: new StringT('nameLength'),
@@ -138,37 +118,28 @@ describe('Struct', function() {
         return this.nameLength = this.name.length;
       };
 
-      struct.encode(stream, {
+      const buf = struct.toBuffer({
         name: 'devon',
         age: 21
-      }
-      );
+      });
 
-      return stream.end();
+      assert.deepEqual(buf, Buffer.from('\x05devon\x15'));
     });
 
-    return it('should encode pointer data after structure', function(done) {
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('\x05devon\x15\x08\x05hello'));
-        return done();
-      })
-      );
-
+    it('should encode pointer data after structure', function() {
       const struct = new Struct({
         name: new StringT(uint8),
         age: uint8,
         ptr: new Pointer(uint8, new StringT(uint8))
       });
 
-      struct.encode(stream, {
+      const buf = struct.toBuffer({
         name: 'devon',
         age: 21,
         ptr: 'hello'
-      }
-      );
+      });
 
-      return stream.end();
+      assert.deepEqual(buf, Buffer.from('\x05devon\x15\x08\x05hello'));
     });
   });
 });

--- a/test/VersionedStruct.js
+++ b/test/VersionedStruct.js
@@ -1,6 +1,5 @@
-const {VersionedStruct, String:StringT, Pointer, uint8, DecodeStream, EncodeStream} = require('../');
-const should = require('chai').should();
-const concat = require('concat-stream');
+import assert from 'assert';
+import {VersionedStruct, String as StringT, Pointer, uint8, DecodeStream, EncodeStream} from 'restructure';
 
 describe('VersionedStruct', function() {
   describe('decode', function() {
@@ -19,14 +18,14 @@ describe('VersionedStruct', function() {
       );
 
       let stream = new DecodeStream(Buffer.from('\x00\x05devon\x15'));
-      struct.decode(stream).should.deep.equal({
+      assert.deepEqual(struct.decode(stream), {
         version: 0,
         name: 'devon',
         age: 21
       });
 
       stream = new DecodeStream(Buffer.from('\x01\x0adevon 👍\x15\x00', 'utf8'));
-      return struct.decode(stream).should.deep.equal({
+      assert.deepEqual(struct.decode(stream), {
         version: 1,
         name: 'devon 👍',
         age: 21,
@@ -49,7 +48,7 @@ describe('VersionedStruct', function() {
       );
 
       const stream = new DecodeStream(Buffer.from('\x05\x05devon\x15'));
-      return should.throw(() => struct.decode(stream));
+      return assert.throws(() => struct.decode(stream));
     });
 
     it('should support common header block', function() {
@@ -69,7 +68,7 @@ describe('VersionedStruct', function() {
       );
 
       let stream = new DecodeStream(Buffer.from('\x00\x15\x01\x05devon'));
-      struct.decode(stream).should.deep.equal({
+      assert.deepEqual(struct.decode(stream), {
         version: 0,
         age: 21,
         alive: 1,
@@ -77,7 +76,7 @@ describe('VersionedStruct', function() {
       });
 
       stream = new DecodeStream(Buffer.from('\x01\x15\x01\x0adevon 👍\x00', 'utf8'));
-      return struct.decode(stream).should.deep.equal({
+      assert.deepEqual(struct.decode(stream), {
         version: 1,
         age: 21,
         alive: 1,
@@ -101,14 +100,14 @@ describe('VersionedStruct', function() {
       );
 
       let stream = new DecodeStream(Buffer.from('\x05devon\x15'));
-      struct.decode(stream, {version: 0}).should.deep.equal({
+      assert.deepEqual(struct.decode(stream, {version: 0}), {
         version: 0,
         name: 'devon',
         age: 21
       });
 
       stream = new DecodeStream(Buffer.from('\x0adevon 👍\x15\x00', 'utf8'));
-      return struct.decode(stream, {version: 1}).should.deep.equal({
+      assert.deepEqual(struct.decode(stream, {version: 1}), {
         version: 1,
         name: 'devon 👍',
         age: 21,
@@ -131,14 +130,14 @@ describe('VersionedStruct', function() {
       );
 
       let stream = new DecodeStream(Buffer.from('\x05devon\x15'));
-      struct.decode(stream, {obj: {version: 0}}).should.deep.equal({
+      assert.deepEqual(struct.decode(stream, {obj: {version: 0}}), {
         version: 0,
         name: 'devon',
         age: 21
       });
 
       stream = new DecodeStream(Buffer.from('\x0adevon 👍\x15\x00', 'utf8'));
-      return struct.decode(stream, {obj: {version: 1}}).should.deep.equal({
+      assert.deepEqual(struct.decode(stream, {obj: {version: 1}}), {
         version: 1,
         name: 'devon 👍',
         age: 21,
@@ -166,27 +165,27 @@ describe('VersionedStruct', function() {
       );
 
       let stream = new DecodeStream(Buffer.from('\x00\x05devon\x15'));
-      struct.decode(stream, {version: 0}).should.deep.equal({
+      assert.deepEqual(struct.decode(stream, {version: 0}), {
         version: 0,
         name: 'devon',
         age: 21
       });
 
       stream = new DecodeStream(Buffer.from('\x01\x00\x05pasta'));
-      struct.decode(stream, {version: 0}).should.deep.equal({
+      assert.deepEqual(struct.decode(stream, {version: 0}), {
         version: 0,
         name: 'pasta'
       });
 
       stream = new DecodeStream(Buffer.from('\x01\x01\x09ice cream\x01'));
-      return struct.decode(stream, {version: 0}).should.deep.equal({
+      assert.deepEqual(struct.decode(stream, {version: 0}), {
         version: 1,
         name: 'ice cream',
         isDesert: 1
       });
     });
 
-    return it('should support process hook', function() {
+    it('should support process hook', function() {
       const struct = new VersionedStruct(uint8, {
         0: {
           name: new StringT(uint8, 'ascii'),
@@ -205,7 +204,7 @@ describe('VersionedStruct', function() {
       };
 
       const stream = new DecodeStream(Buffer.from('\x00\x05devon\x15'));
-      return struct.decode(stream).should.deep.equal({
+      assert.deepEqual(struct.decode(stream), {
         version: 0,
         name: 'devon',
         age: 21,
@@ -235,7 +234,7 @@ describe('VersionedStruct', function() {
         age: 21
       });
 
-      size.should.equal(8);
+      assert.equal(size, 8);
 
       size = struct.size({
         version: 1,
@@ -244,7 +243,7 @@ describe('VersionedStruct', function() {
         gender: 0
       });
 
-      return size.should.equal(14);
+      assert.equal(size, 14);
     });
 
     it('should throw for unknown version', function() {
@@ -261,7 +260,7 @@ describe('VersionedStruct', function() {
       }
       );
 
-      return should.throw(() =>
+      assert.throws(() =>
         struct.size({
           version: 5,
           name: 'devon',
@@ -293,7 +292,7 @@ describe('VersionedStruct', function() {
         name: 'devon'
       });
 
-      size.should.equal(9);
+      assert.equal(size, 9);
 
       size = struct.size({
         version: 1,
@@ -303,7 +302,7 @@ describe('VersionedStruct', function() {
         gender: 0
       });
 
-      return size.should.equal(15);
+      assert.equal(size, 15);
     });
 
     it('should compute the correct size with pointers', function() {
@@ -327,10 +326,10 @@ describe('VersionedStruct', function() {
         ptr: 'hello'
       });
 
-      return size.should.equal(15);
+      assert.equal(size, 15);
     });
 
-    return it('should throw if no value is given', function() {
+    it('should throw if no value is given', function() {
       const struct = new VersionedStruct(uint8, {
         0: {
           name: new StringT(4, 'ascii'),
@@ -344,13 +343,12 @@ describe('VersionedStruct', function() {
       }
       );
 
-      return should.throw(() => struct.size()
-      , /not a fixed size/i);
+      assert.throws(() => struct.size(), /not a fixed size/i);
     });
   });
 
-  return describe('encode', function() {
-    it('should encode objects to buffers', function(done) {
+  describe('encode', function() {
+    it('should encode objects to buffers', function() {
       const struct = new VersionedStruct(uint8, {
         0: {
           name: new StringT(uint8, 'ascii'),
@@ -361,32 +359,24 @@ describe('VersionedStruct', function() {
           age: uint8,
           gender: uint8
         }
-      }
-      );
+      });
 
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('\x00\x05devon\x15\x01\x0adevon 👍\x15\x00', 'utf8'));
-        return done();
-      })
-      );
-
-      struct.encode(stream, {
+      const buf1 = struct.toBuffer({
         version: 0,
         name: 'devon',
         age: 21
-      }
-      );
+      });
 
-      struct.encode(stream, {
+      assert.deepEqual(buf1,  Buffer.from('\x00\x05devon\x15', 'utf8'));
+
+      const buf2 = struct.toBuffer({
         version: 1,
         name: 'devon 👍',
         age: 21,
         gender: 0
-      }
-      );
+      });
 
-      return stream.end();
+      assert.deepEqual(buf2,  Buffer.from('\x01\x0adevon 👍\x15\x00', 'utf8'));
     });
 
     it('should throw for unknown version', function() {
@@ -400,21 +390,18 @@ describe('VersionedStruct', function() {
           age: uint8,
           gender: uint8
         }
-      }
-      );
+      });
 
-      const stream = new EncodeStream;
-      return should.throw(() =>
-        struct.encode(stream, {
+      assert.throws(() =>
+        struct.toBuffer({
           version: 5,
           name: 'devon',
           age: 21
-        }
-        )
+        })
       );
     });
 
-    it('should support common header block', function(done) {
+    it('should support common header block', function() {
       const struct = new VersionedStruct(uint8, {
         header: {
           age: uint8,
@@ -427,37 +414,29 @@ describe('VersionedStruct', function() {
           name: new StringT(uint8, 'utf8'),
           gender: uint8
         }
-      }
-      );
+      });
 
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('\x00\x15\x01\x05devon\x01\x15\x01\x0adevon 👍\x00', 'utf8'));
-        return done();
-      })
-      );
-
-      struct.encode(stream, {
+      const buf1 = struct.toBuffer({
         version: 0,
         age: 21,
         alive: 1,
         name: 'devon'
-      }
-      );
+      });
 
-      struct.encode(stream, {
+      assert.deepEqual(buf1, Buffer.from('\x00\x15\x01\x05devon', 'utf8'));
+
+      const buf2 = struct.toBuffer({
         version: 1,
         age: 21,
         alive: 1,
         name: 'devon 👍',
         gender: 0
-      }
-      );
+      });
 
-      return stream.end();
+      assert.deepEqual(buf2, Buffer.from('\x01\x15\x01\x0adevon 👍\x00', 'utf8'));
     });
 
-    it('should encode pointer data after structure', function(done) {
+    it('should encode pointer data after structure', function() {
       const struct = new VersionedStruct(uint8, {
         0: {
           name: new StringT(uint8, 'ascii'),
@@ -468,28 +447,19 @@ describe('VersionedStruct', function() {
           age: uint8,
           ptr: new Pointer(uint8, new StringT(uint8))
         }
-      }
-      );
+      });
 
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('\x01\x05devon\x15\x09\x05hello', 'utf8'));
-        return done();
-      })
-      );
-
-      struct.encode(stream, {
+      const buf = struct.toBuffer({
         version: 1,
         name: 'devon',
         age: 21,
         ptr: 'hello'
-      }
-      );
+      });
 
-      return stream.end();
+      assert.deepEqual(buf, Buffer.from('\x01\x05devon\x15\x09\x05hello', 'utf8'));
     });
 
-    return it('should support preEncode hook', function(done) {
+    it('should support preEncode hook', function() {
       const struct = new VersionedStruct(uint8, {
         0: {
           name: new StringT(uint8, 'ascii'),
@@ -500,34 +470,26 @@ describe('VersionedStruct', function() {
           age: uint8,
           gender: uint8
         }
-      }
-      );
+      });
 
       struct.preEncode = function() {
         return this.version = (this.gender != null) ? 1 : 0;
       };
 
-      const stream = new EncodeStream;
-      stream.pipe(concat(function(buf) {
-        buf.should.deep.equal(Buffer.from('\x00\x05devon\x15\x01\x0adevon 👍\x15\x00', 'utf8'));
-        return done();
-      })
-      );
-
-      struct.encode(stream, {
+      const buf1 = struct.toBuffer({
         name: 'devon',
         age: 21
-      }
-      );
+      });
 
-      struct.encode(stream, {
+      assert.deepEqual(buf1, Buffer.from('\x00\x05devon\x15', 'utf8'));
+
+      const buf2 = struct.toBuffer({
         name: 'devon 👍',
         age: 21,
         gender: 0
-      }
-      );
+      });
 
-      return stream.end();
+      assert.deepEqual(buf2, Buffer.from('\x01\x0adevon 👍\x15\x00', 'utf8'));
     });
   });
 });


### PR DESCRIPTION
Closes #24

This drops Node Buffer usages, and replaces them with Uint8Array, DataView, and TextDecoder/TextEncoder, which are standard browser APIs also supported by Node.

iconv-lite usages are also dropped. Unfortunately, TextEncoder only supports utf8, while TextDecoder supports many legacy encodings. This means that decoding legacy encodings is supported with no bundle size implications, but encoding is not supported. This should be ok for fontkit but it is a breaking change.

The one remaining node API in use is streams. Web Streams unfortunately are only supported in Node 16, but Node 14 is still LTS. I suppose we could require a polyfill but that's not great...