### PR TITLE
fix: null terminated string support for utf16

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ var struct = new r.Struct({
 
 ### String
 
-A `String` maps a JavaScript string to and from binary encodings.  The length can be a constant, taken
-from a previous field in the parent structure, or encoded using a number type immediately before the string.
+A `String` maps a JavaScript string to and from binary encodings.  The length, in bytes, can be a constant,
+taken from a previous field in the parent structure, encoded using a number type immediately before the
+string.
 
 Fully supported encodings include `'ascii'`, `'utf8'`, `'ucs2'`, `'utf16le'`, `'utf16be'`. Decoding is also possible
 with any encoding supported by [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API/Encodings),
@@ -172,7 +173,7 @@ var struct = new r.Struct({
 });
 
 // null-terminated string (also known as C string)
-var str = new r.String(null, 'utf8')
+var str = new r.String(null, 'utf8');
 ```
 
 ### Array

--- a/src/String.js
+++ b/src/String.js
@@ -12,28 +12,33 @@ class StringT extends Base {
   decode(stream, parent) {
     let length, pos;
 
+    let { encoding } = this;
+    if (typeof encoding === 'function') {
+      encoding = encoding.call(parent, parent) || 'ascii';
+    }
+    let width = encodingWidth(encoding);
+
     if (this.length != null) {
       length = utils.resolveLength(this.length, stream, parent);
     } else {
       let buffer;
       ({buffer, length, pos} = stream);
 
-      while ((pos < length) && (buffer[pos] !== 0x00)) {
-        ++pos;
+      while ((pos < length - width + 1) &&
+        (buffer[pos] !== 0x00 ||
+        (width === 2 && buffer[pos+1] !== 0x00)
+        )) {
+        pos += width;
       }
 
       length = pos - stream.pos;
     }
 
-    let { encoding } = this;
-    if (typeof encoding === 'function') {
-      encoding = encoding.call(parent, parent) || 'ascii';
-    }
 
     const string = stream.readString(length, encoding);
 
     if ((this.length == null) && (stream.pos < stream.length)) {
-      stream.pos++;
+      stream.pos+=width;
     }
 
     return string;
@@ -60,7 +65,7 @@ class StringT extends Base {
     }
 
     if ((this.length == null)) {
-      size++;
+      size += encodingWidth(encoding);
     }
 
     return size;
@@ -79,8 +84,26 @@ class StringT extends Base {
     stream.writeString(val, encoding);
 
     if ((this.length == null)) {
-      return stream.writeUInt8(0x00);
+      return encodingWidth(encoding) == 2 ?
+        stream.writeUInt16LE(0x0000) :
+        stream.writeUInt8(0x00);
     }
+  }
+}
+
+function encodingWidth(encoding) {
+  switch(encoding) {
+    case 'ascii':
+    case 'utf8': // utf8 is a byte-based encoding for zero-term string
+      return 1;
+    case 'utf16le':
+    case 'utf16-le':
+    case 'utf16be':
+    case 'utf16-be':
+    case 'ucs2':
+      return 2;
+    default:
+      throw new Error('Unknown encoding ' + encoding);
   }
 }
 

--- a/src/String.js
+++ b/src/String.js
@@ -46,7 +46,7 @@ class StringT extends Base {
 
   size(val, parent) {
     // Use the defined value if no value was given
-    if (!val) {
+    if (val === undefined || val === null) {
       return utils.resolveLength(this.length, null, parent);
     }
 


### PR DESCRIPTION
Fixes #51.

Fixes a couple of issues around two-byte encodings:
* the length of the buffer was wrongly calculated, 
* for zero-terminated buffers, a single null byte was treated as end-of-string for double-byte encodings.

Also, `size("")` was treated the same as `size()` as zero-length string is falsy.
