### PR TITLE
Ignore .parcel-cache directory when publishing to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 .github/
+.parcel-cache/
 node_modules/
 coverage/
 coverage.html


### PR DESCRIPTION
It adds 4.5 MB to the package but is not needed.