### PR TITLE
Pass parent to computed properties of struct

### DIFF
--- a/src/Struct.js
+++ b/src/Struct.js
@@ -9,7 +9,7 @@ export class Struct extends Base {
 
   decode(stream, parent, length = 0) {
     const res = this._setup(stream, parent, length);
-    this._parseFields(stream, res, this.fields);
+    this._parseFields(stream, res, this.fields, parent);
 
     if (this.process != null) {
       this.process.call(res, stream);
@@ -31,12 +31,12 @@ export class Struct extends Base {
     return res;
   }
 
-  _parseFields(stream, res, fields) {
+  _parseFields(stream, res, fields, parent) {
     for (let key in fields) {
       var val;
       const type = fields[key];
       if (typeof type === 'function') {
-        val = type.call(res, res);
+        val = type.call(res, res, parent);
       } else {
         val = type.decode(stream, res);
       }


### PR DESCRIPTION
This PR allows you to read properties not only from current context but from the parent context when writing a computed property of a struct.

```js
const Foo = new r.Struct({
  type: r.uint32,
  data: new r.Struct({
    buff: new r.Buffer(64),
    values(_, parent) {
      switch (parent.type) {
        // ...
      }
    }
  })
})
```