### PR TITLE
fix: StringT: re-support other string encodings

### DIFF
--- a/src/String.js
+++ b/src/String.js
@@ -98,12 +98,16 @@ function encodingWidth(encoding) {
       return 1;
     case 'utf16le':
     case 'utf16-le':
+    case 'utf-16be':
+    case 'utf-16le':
     case 'utf16be':
     case 'utf16-be':
     case 'ucs2':
       return 2;
     default:
-      throw new Error('Unknown encoding ' + encoding);
+      //TODO: assume all other encodings are 1-byters
+      //throw new Error('Unknown encoding ' + encoding);
+      return 1;
   }
 }
 

--- a/test/String.js
+++ b/test/String.js
@@ -52,6 +52,12 @@ describe('String', function() {
       const string = new StringT(null, 'utf16le');
       assert.equal(string.fromBuffer(Buffer.from('🍻', 'utf16le')), '🍻');
     });
+
+    it('should decode x-mac-roman', function() {
+      const string = new StringT(null, 'x-mac-roman');
+      const buf = new Uint8Array([0x8a, 0x63, 0x63, 0x65, 0x6e, 0x74, 0x65, 0x64, 0x20, 0x63, 0x68, 0x87, 0x72, 0x61, 0x63, 0x74, 0x65, 0x72, 0x73]);
+      assert.equal(string.fromBuffer(buf), 'äccented cháracters');
+    })
   });
 
   describe('size', function() {


### PR DESCRIPTION
- Fixes https://github.com/foliojs/restructure/issues/60
- Fixes https://github.com/foliojs/fontkit/issues/331 - allows fontkit's unit tests to pass
- Probably fixes #61 

- add a test for 'x-mac-roman'
- add two utf-16 alias names
- if an encoding is otherwise unknown, assume 1-byte length
(this matches prior behavior)

History: #59 enabled support for 2-byte utf encodings, which were previously broken. So #59+#62 presents no regression for any other encodings.