### PR TITLE
feat: Export Base class

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+export {Base} from './src/Base.js';
 export {EncodeStream} from './src/EncodeStream.js';
 export {DecodeStream} from './src/DecodeStream.js';
 export {Array} from './src/Array.js';


### PR DESCRIPTION
For writing custom types it helps to have Base accessible.
My current workaround is to use ` class MyType extends r.Optional.__proto__`