### PR TITLE
Avoid publishing tests to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "import": "./index.js",
     "require": "./dist/main.cjs"
   },
+  "files": [
+    "dist",
+    "src",
+    "index.js"
+  ],
   "targets": {
     "module": false
   },


### PR DESCRIPTION
Currently this package includes 65 KB of test files in the code published to npm. This PR adds a `files` field to `package.json` to avoid publishing these unused files.

Would you also be open to removing the `src` directory and sourcemaps in published files? That would further reduce the install size significantly.